### PR TITLE
Implement Minecraft 1.19.2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Minecraft HTTP Interface Mod (Minecraft 1.16.5)
+# Minecraft HTTP Interface Mod (Minecraft 1.19.2)
 
 This repo is based on the [GDMC example mod](https://github.com/Lasbleic/gdmc_java_mod) which is based on the Forge MDK.
 
-The latest release is [0.4.1 for Minecraft version 1.16.5](https://github.com/nilsgawlik/gdmc_http_interface/releases/tag/v0.4.1)
+The latest release is [0.5.0 for Minecraft version 1.19.2](https://github.com/Niels-NTG/gdmc_http_interface/releases/tag/v0.5.0)
 
 ## What it's all about
 
@@ -10,7 +10,7 @@ The latest release is [0.4.1 for Minecraft version 1.16.5](https://github.com/ni
 
 This mod opens an HTTP interface so that other programs (on the same machine) can read and modify the world. It is meant as a tool to be used for the [Generative Design in Minecraft Competition](http://gendesignmc.engineering.nyu.edu/).
 
-When you open a Minecraft world, this mod opens an HTTP Server on localhost:9000. I recommend using Postman or a similar application to test out the http interface. A Python example of how to use the interface can be found [here](https://github.com/nilsgawlik/gdmc_http_client_python).
+When you open a Minecraft world, this mod opens an HTTP Server on localhost:9000. I recommend using Postman or a similar application to test out the http interface. A Python example of how to use the interface can be found [here](https://github.com/avdstaaij/gdpc).
 
 ## Features / HTTP Endpoints
 
@@ -23,9 +23,9 @@ GET     /chunks     Get raw chunk nbt data
 GET     /buildarea  Get the build area defined by the /setbuildarea chat command
 ```
 
-A detailed documentation of the endpoints can be found [over here](https://github.com/nilsgawlik/gdmc_http_interface/wiki/Interface-Endpoints).
+A detailed documentation of the endpoints can be found [over here](https://github.com/Niels-NTG/gdmc_http_interface/wiki/Interface-Endpoints).
 
 ## Installation
 
-Install instructions are [over here](https://github.com/nilsgawlik/gdmc_http_interface/wiki/Installation).
+Install instructions are [over here](https://github.com/Niels-NTG/gdmc_http_interface/wiki/Installation).
 You need to own a copy of Minecraft to use the http interface!

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ minecraft {
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
 //    mappings channel: 'snapshot', version: '20200514-1.15.1'
-    mappings channel: 'official', version: '1.18.2'
+    mappings channel: 'official', version: '1.19'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -95,7 +95,8 @@ dependencies {
 //    minecraft 'net.minecraftforge:forge:1.16.3-34.1.0'
 //    minecraft 'net.minecraftforge:forge:1.16.4-35.1.4'
 //    minecraft 'net.minecraftforge:forge:1.16.5-36.1.0'
-    minecraft 'net.minecraftforge:forge:1.18.2-40.1.0'
+//    minecraft 'net.minecraftforge:forge:1.18.2-40.1.0'
+    minecraft 'net.minecraftforge:forge:1.19-41.0.45'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ dependencies {
 //    minecraft 'net.minecraftforge:forge:1.18.2-40.1.0'
 //    minecraft 'net.minecraftforge:forge:1.19-41.0.98'
 //    minecraft 'net.minecraftforge:forge:1.19-41.1.0'
-    minecraft 'net.minecraftforge:forge:1.19.2-43.1.1'
+    minecraft 'net.minecraftforge:forge:1.19.2-43.1.7'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.+', changing: true
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
     }
 }
 apply plugin: 'net.minecraftforge.gradle'
@@ -26,7 +26,7 @@ minecraft {
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
 //    mappings channel: 'snapshot', version: '20200514-1.15.1'
-    mappings channel: 'official', version: '1.19'
+    mappings channel: 'official', version: '1.19.2'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
@@ -96,7 +96,9 @@ dependencies {
 //    minecraft 'net.minecraftforge:forge:1.16.4-35.1.4'
 //    minecraft 'net.minecraftforge:forge:1.16.5-36.1.0'
 //    minecraft 'net.minecraftforge:forge:1.18.2-40.1.0'
-    minecraft 'net.minecraftforge:forge:1.19-41.0.61'
+//    minecraft 'net.minecraftforge:forge:1.19-41.0.98'
+//    minecraft 'net.minecraftforge:forge:1.19-41.1.0'
+    minecraft 'net.minecraftforge:forge:1.19.2-43.1.1'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"
@@ -147,7 +149,7 @@ publishing {
     }
     repositories {
         maven {
-            url "file:///${project.projectDir}/mcmodsrepo"
+            url "file://${project.projectDir}/mcmodsrepo"
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ version = '0.5.0'
 group = 'com.nilsgawlik.gdmchttp' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'gdmchttp'
 
-sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '18' // Need this here so eclipse task generates correctly.
+sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '17' // Need this here so eclipse task generates correctly.
 
 minecraft {
     // The mappings can be changed at any time, and must be in the following format.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '3.+', changing: true
+        classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.+', changing: true
     }
 }
 apply plugin: 'net.minecraftforge.gradle'
@@ -13,11 +13,11 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = '0.4.2'
+version = '0.5.0'
 group = 'com.nilsgawlik.gdmchttp' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'gdmchttp'
 
-sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
+sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility = '18' // Need this here so eclipse task generates correctly.
 
 minecraft {
     // The mappings can be changed at any time, and must be in the following format.
@@ -26,9 +26,9 @@ minecraft {
     // Use non-default mappings at your own risk. they may not always work.
     // Simply re-run your setup task after changing the mappings to update your workspace.
 //    mappings channel: 'snapshot', version: '20200514-1.15.1'
-    mappings channel: 'snapshot', version: '20210309-1.16.5'
+    mappings channel: 'official', version: '1.18.2'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
-    
+
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
     // Default run configurations.
@@ -44,7 +44,7 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             mods {
-                examplemod {
+                gdmchttp {
                     source sourceSets.main
                 }
             }
@@ -60,7 +60,7 @@ minecraft {
             property 'forge.logging.console.level', 'debug'
 
             mods {
-                examplemod {
+                gdmchttp {
                     source sourceSets.main
                 }
             }
@@ -75,10 +75,10 @@ minecraft {
             // Recommended logging level for the console
             property 'forge.logging.console.level', 'debug'
 
-            args '--mod', 'examplemod', '--all', '--output', file('src/generated/resources/')
+            args '--mod', 'gdmchttp', '--all', '--output', file('src/generated/resources/')
 
             mods {
-                examplemod {
+                gdmchttp {
                     source sourceSets.main
                 }
             }
@@ -94,8 +94,8 @@ dependencies {
 //    minecraft 'net.minecraftforge:forge:1.15.2-31.2.31'
 //    minecraft 'net.minecraftforge:forge:1.16.3-34.1.0'
 //    minecraft 'net.minecraftforge:forge:1.16.4-35.1.4'
-    minecraft 'net.minecraftforge:forge:1.16.5-36.1.0'
-
+//    minecraft 'net.minecraftforge:forge:1.16.5-36.1.0'
+    minecraft 'net.minecraftforge:forge:1.18.2-40.1.0'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"
@@ -121,12 +121,12 @@ dependencies {
 jar {
     manifest {
         attributes([
-            "Specification-Title": "examplemod",
-            "Specification-Vendor": "examplemodsareus",
+            "Specification-Title": "gdmchttp",
+            "Specification-Vendor": "gdmchttpsareus",
             "Specification-Version": "1", // We are version 1 of ourselves
             "Implementation-Title": project.name,
             "Implementation-Version": "${version}",
-            "Implementation-Vendor" :"examplemodsareus",
+            "Implementation-Vendor" :"gdmchttpsareus",
             "Implementation-Timestamp": new Date().format("yyyy-MM-dd'T'HH:mm:ssZ")
         ])
     }
@@ -134,7 +134,7 @@ jar {
 
 // Example configuration to allow publishing using the maven-publish task
 // This is the preferred method to reobfuscate your jar file
-jar.finalizedBy('reobfJar') 
+jar.finalizedBy('reobfJar')
 // However if you are in a multi-project build, dev time needs unobfed jar files, so you can delay the obfuscation until publishing by doing
 //publish.dependsOn('reobfJar')
 

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,7 @@ dependencies {
 //    minecraft 'net.minecraftforge:forge:1.16.4-35.1.4'
 //    minecraft 'net.minecraftforge:forge:1.16.5-36.1.0'
 //    minecraft 'net.minecraftforge:forge:1.18.2-40.1.0'
-    minecraft 'net.minecraftforge:forge:1.19-41.0.45'
+    minecraft 'net.minecraftforge:forge:1.19-41.0.61'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpMod.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpMod.java
@@ -1,20 +1,18 @@
 package com.gdmc.httpinterfacemod;
 
 import com.gdmc.httpinterfacemod.utils.RegistryHandler;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.Util;
-import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.StringTextComponent;
 import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.server.ServerStartingEvent;
+import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
-import net.minecraftforge.fml.event.server.FMLServerStoppingEvent;
-import net.minecraftforge.fml.loading.FMLCommonLaunchHandler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.util.UUID;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod("gdmchttp")
@@ -32,23 +30,25 @@ public class GdmcHttpMod
 
     // You can use SubscribeEvent and let the Event Bus discover methods to call
     @SubscribeEvent
-    public void onServerStarting(FMLServerStartingEvent event) {
+    public void onServerStarting(ServerStartingEvent event) {
         // do something when the server starts
         LOGGER.info("HELLO from server starting");
         RegistryHandler.registerCommands(event);
         MinecraftServer minecraftServer = event.getServer();
 
+        UUID uuid = UUID.randomUUID();
+
         try {
             GdmcHttpServer.startServer(minecraftServer);
-            minecraftServer.sendMessage(new StringTextComponent("GDMC Server started successfully."), Util.DUMMY_UUID);
+            minecraftServer.sendMessage(Component.nullToEmpty("GDMC Server started successfully."), uuid);
         } catch (IOException e) {
             LOGGER.warn("Unable to start server!");
-            minecraftServer.sendMessage(new StringTextComponent("GDMC Server failed to start!"), Util.DUMMY_UUID);
+            minecraftServer.sendMessage(Component.nullToEmpty("GDMC Server failed to start!"), uuid);
         }
     }
 
     @SubscribeEvent
-    public void onServerStopping(FMLServerStoppingEvent event) {
+    public void onServerStopping(ServerStoppingEvent event) {
         LOGGER.info("HELLO from server stopping");
 
         GdmcHttpServer.stopServer();

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpMod.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpMod.java
@@ -12,7 +12,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
-import java.util.UUID;
 
 // The value here should match an entry in the META-INF/mods.toml file
 @Mod("gdmchttp")
@@ -36,14 +35,12 @@ public class GdmcHttpMod
         RegistryHandler.registerCommands(event);
         MinecraftServer minecraftServer = event.getServer();
 
-        UUID uuid = UUID.randomUUID();
-
         try {
             GdmcHttpServer.startServer(minecraftServer);
-            minecraftServer.sendMessage(Component.nullToEmpty("GDMC Server started successfully."), uuid);
+            minecraftServer.sendSystemMessage(Component.nullToEmpty("GDMC Server started successfully."));
         } catch (IOException e) {
             LOGGER.warn("Unable to start server!");
-            minecraftServer.sendMessage(Component.nullToEmpty("GDMC Server failed to start!"), uuid);
+            minecraftServer.sendSystemMessage(Component.nullToEmpty("GDMC Server failed to start!"));
         }
     }
 

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
@@ -2,7 +2,6 @@ package com.gdmc.httpinterfacemod;
 
 import com.gdmc.httpinterfacemod.handlers.*;
 import com.sun.net.httpserver.HttpServer;
-import net.minecraft.command.CommandSource;
 import net.minecraft.server.MinecraftServer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/BlocksHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/BlocksHandler.java
@@ -193,7 +193,6 @@ public class BlocksHandler extends HandlerBase {
     private int setBlock(BlockPos pos, BlockState blockState, CompoundTag blockEntityData, int flags) {
         ServerLevel serverLevel = mcServer.overworld();
 
-        assert serverLevel != null;
         BlockEntity blockEntitytoClear = serverLevel.getBlockEntity(pos);
         Clearable.tryClear(blockEntitytoClear);
 
@@ -234,8 +233,6 @@ public class BlocksHandler extends HandlerBase {
     private String getBlockAsStr(BlockPos pos) {
         ServerLevel serverLevel = mcServer.overworld();
 
-        assert serverLevel != null;
-
         BlockState bs = serverLevel.getBlockState(pos);
         return Objects.requireNonNull(getBlockRegistryName(bs));
     }
@@ -243,7 +240,6 @@ public class BlocksHandler extends HandlerBase {
     private JsonObject getBlockStateAsJsonObject(BlockPos pos) {
         ServerLevel serverLevel = mcServer.overworld();
 
-        assert serverLevel != null;
         BlockState bs = serverLevel.getBlockState(pos);
 
         JsonObject stateJsonObject = new JsonObject();
@@ -255,7 +251,6 @@ public class BlocksHandler extends HandlerBase {
     private String getBlockStateAsStr(BlockPos pos) {
         ServerLevel serverLevel = mcServer.overworld();
 
-        assert serverLevel != null;
         BlockState bs = serverLevel.getBlockState(pos);
 
         return '[' +
@@ -266,8 +261,6 @@ public class BlocksHandler extends HandlerBase {
     private String getBlockDataAsStr(BlockPos pos) {
         String str = "";
         ServerLevel serverLevel = mcServer.overworld();
-
-        assert serverLevel != null;
 
         BlockEntity blockEntity = serverLevel.getExistingBlockEntity(pos);
         if (blockEntity != null) {

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/BuildAreaHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/BuildAreaHandler.java
@@ -6,8 +6,6 @@ import com.sun.net.httpserver.HttpExchange;
 import net.minecraft.server.MinecraftServer;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 
 public class BuildAreaHandler extends HandlerBase {
     public static class BuildArea {

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/ChunkHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/ChunkHandler.java
@@ -53,7 +53,6 @@ public class ChunkHandler extends HandlerBase {
 
         // construct response
         ServerLevel serverLevel = mcServer.overworld();
-        assert serverLevel != null;
 
         CompletableFuture<ListTag> cfs = CompletableFuture.supplyAsync(() -> {
             ListTag returnList = new ListTag();

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/CommandHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/CommandHandler.java
@@ -3,13 +3,12 @@ package com.gdmc.httpinterfacemod.handlers;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
-import net.minecraft.command.CommandSource;
+import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.MinecraftServer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.*;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -17,7 +16,7 @@ import java.util.stream.Collectors;
 
 public class CommandHandler extends HandlerBase {
     private static final Logger LOGGER = LogManager.getLogger();
-    private final CommandSource cmdSrc;
+    private final CommandSourceStack cmdSrc;
 
     public CommandHandler(MinecraftServer mcServer) {
         super(mcServer);
@@ -38,7 +37,7 @@ public class CommandHandler extends HandlerBase {
             CompletableFuture<String> cfs = CompletableFuture.supplyAsync(() -> {
                 String str;
                 try {
-                    str = "" + mcServer.getCommandManager().getDispatcher().execute(command, cmdSrc);
+                    str = "" + mcServer.getCommands().getDispatcher().execute(command, cmdSrc);
                 } catch (CommandSyntaxException e) {
                     LOGGER.error(e.getMessage());
                     str = e.getMessage();

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
@@ -3,14 +3,12 @@ package com.gdmc.httpinterfacemod.handlers;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
-import net.minecraft.command.CommandSource;
-import net.minecraft.command.ICommandSource;
+import net.minecraft.commands.CommandSource;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.math.vector.Vector2f;
-import net.minecraft.util.math.vector.Vector3d;
-import net.minecraft.util.text.ITextComponent;
-import net.minecraft.util.text.StringTextComponent;
-import net.minecraft.world.World;
+import net.minecraft.world.phys.Vec2;
+import net.minecraft.world.phys.Vec3;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -128,24 +126,39 @@ public abstract class HandlerBase implements HttpHandler {
         return result;
     }
 
-    protected static CommandSource createCommandSource(String name, MinecraftServer mcServer) {
-        ICommandSource iCmdSrc = new ICommandSource() {
-            @Override public void sendMessage(ITextComponent component, UUID senderUUID) { }
-            @Override public boolean shouldReceiveFeedback() { return false; }
-            @Override public boolean shouldReceiveErrors() { return false; }
-            @Override public boolean allowLogging() { return false; }
+    protected static CommandSourceStack createCommandSource(String name, MinecraftServer mcServer) {
+        CommandSource commandSource = new CommandSource() {
+            @Override
+            public void sendMessage(Component p_80166_, UUID p_80167_) {
+
+            }
+
+            @Override
+            public boolean acceptsSuccess() {
+                return false;
+            }
+
+            @Override
+            public boolean acceptsFailure() {
+                return false;
+            }
+
+            @Override
+            public boolean shouldInformAdmins() {
+                return false;
+            }
         };
 
-        return new CommandSource(
-                iCmdSrc,
-                new Vector3d(0, 0, 0),
-                new Vector2f(0, 0),
-                Objects.requireNonNull(mcServer.getWorld(World.OVERWORLD)),
-                4,
-                name,
-                new StringTextComponent(name),
-                mcServer,
-                null
+        return new CommandSourceStack(
+            commandSource,
+            new Vec3(0, 0, 0),
+            new Vec2(0, 0),
+            mcServer.overworld(),
+            4,
+            name,
+            Component.nullToEmpty(name),
+            mcServer,
+            null
         );
     }
 }

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
@@ -129,7 +129,7 @@ public abstract class HandlerBase implements HttpHandler {
     protected static CommandSourceStack createCommandSource(String name, MinecraftServer mcServer) {
         CommandSource commandSource = new CommandSource() {
             @Override
-            public void sendMessage(Component p_80166_, UUID p_80167_) {
+            public void sendSystemMessage(Component p_230797_) {
 
             }
 

--- a/src/main/java/com/gdmc/httpinterfacemod/settlementcommand/SetBuildAreaCommand.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/settlementcommand/SetBuildAreaCommand.java
@@ -3,11 +3,11 @@ package com.gdmc.httpinterfacemod.settlementcommand;
 import com.gdmc.httpinterfacemod.handlers.BuildAreaHandler;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.context.CommandContext;
-import net.minecraft.command.CommandSource;
-import net.minecraft.command.Commands;
-import net.minecraft.command.arguments.BlockPosArgument;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.text.StringTextComponent;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -18,17 +18,17 @@ public class SetBuildAreaCommand<S> {
 
     private SetBuildAreaCommand() { }
 
-    public static void register(CommandDispatcher<CommandSource> dispatcher) {
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         dispatcher.register(
                 Commands.literal(COMMAND_NAME)
                 .then(Commands.argument("from", BlockPosArgument.blockPos())
                 .then(Commands.argument("to", BlockPosArgument.blockPos())
                 .executes( context -> {
-                    return perform(context, BlockPosArgument.getBlockPos(context, "from"), BlockPosArgument.getBlockPos(context, "to"));
+                    return perform(context, BlockPosArgument.getLoadedBlockPos(context, "from"), BlockPosArgument.getLoadedBlockPos(context, "to"));
                 }))));
     }
 
-    private static int perform(CommandContext<CommandSource> commandSourceContext, BlockPos from, BlockPos to) {
+    private static int perform(CommandContext<CommandSourceStack> commandSourceContext, BlockPos from, BlockPos to) {
         int x1 = from.getX();
         int y1 = from.getY();
         int z1 = from.getZ();
@@ -38,7 +38,7 @@ public class SetBuildAreaCommand<S> {
 
         BuildAreaHandler.setBuildArea(x1, y1, z1, x2, y2, z2);
         String feedback = String.format("Build area set to %d, %d, %d to %d, %d, %d,", x1, y1, z1, x2, y2, z2 );
-        commandSourceContext.getSource().sendFeedback(new StringTextComponent(feedback), true);
+        commandSourceContext.getSource().sendSuccess(Component.nullToEmpty(feedback), true);
         LOGGER.info(feedback);
         return 1;
     }

--- a/src/main/java/com/gdmc/httpinterfacemod/utils/RegistryHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/utils/RegistryHandler.java
@@ -2,15 +2,15 @@ package com.gdmc.httpinterfacemod.utils;
 
 import com.gdmc.httpinterfacemod.settlementcommand.SetBuildAreaCommand;
 import com.mojang.brigadier.CommandDispatcher;
-import net.minecraft.command.CommandSource;
-import net.minecraftforge.fml.event.server.FMLServerStartingEvent;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraftforge.event.server.ServerStartingEvent;
 
 public class RegistryHandler {
 
-    public static void registerCommands(FMLServerStartingEvent event) {
+    public static void registerCommands(ServerStartingEvent event) {
 
         // TODO might be wrong (didn't test)
-        CommandDispatcher<CommandSource> dispatcher = event.getServer().getCommandManager().getDispatcher();
+        CommandDispatcher<CommandSourceStack> dispatcher = event.getServer().getCommands().getDispatcher();
         SetBuildAreaCommand.register(dispatcher);
         // maybe try this instead:
 //        CommandDispatcher<CommandSource> dispatcher = event.getServer().getFunctionManager().getCommandDispatcher();

--- a/src/main/java/com/gdmc/httpinterfacemod/utils/UtilityFunctions.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/utils/UtilityFunctions.java
@@ -1,19 +1,5 @@
 package com.gdmc.httpinterfacemod.utils;
 
-import javafx.util.Pair;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Blocks;
-import net.minecraft.command.arguments.BlockStateInput;
-import net.minecraft.state.properties.BlockStateProperties;
-import net.minecraft.util.Direction;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
-import net.minecraftforge.client.model.generators.IGeneratedBlockstate;
-
-import javax.annotation.Nullable;
-import java.util.*;
-
 public abstract class UtilityFunctions {
 
         // TODO 1.16 actually broke a bunch of this stuff, but we don't need it yet

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[41,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[43,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="MIT"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -6,7 +6,7 @@
 # The name of the mod loader type to load - for regular FML @Mod mods it should be javafml
 modLoader="javafml" #mandatory
 # A version range to match for said mod loader - for regular FML @Mod it will be the forge version
-loaderVersion="[31,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[41,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
 # The license for you mod. This is mandatory metadata and allows for easier comprehension of your redistributive properties.
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="MIT"

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -11,7 +11,7 @@ loaderVersion="[31,)" #mandatory This is typically bumped every Minecraft versio
 # Review your options at https://choosealicense.com/. All rights reserved is the default copyright stance, and is thus the default here.
 license="MIT"
 # A URL to refer people to when problems occur with this mod
-issueTrackerURL="http://my.issue.tracker/" #optional
+issueTrackerURL="https://github.com/Niels-NTG/gdmc_http_interface/issues" #optional
 # A list of mods - how many allowed here is determined by the individual mod loader
 [[mods]] #mandatory
 # The modid of the mod
@@ -29,28 +29,9 @@ displayName="GDMC HTTP Interface Mod" #mandatory
 # A text field displayed in the mod UI
 credits="Thanks to the GDMC community and organizers" #optional
 # A text field displayed in the mod UI
-authors="Nils Gawlik" #optional
+authors="Nils Gawlik, Niels NTG Poldervaart" #optional
 # The description text for the mod (multi line!) (#mandatory)
 description='''
 This is a mod that provides an http interface for things such as setting/getting blocks,
 running commands and getting chunk data
 '''
-# A dependency - use the . to indicate dependency for a specific modid. Dependencies are optional.
-[[dependencies.examplemod]] #optional
-    # the modid of the dependency
-    modId="forge" #mandatory
-    # Does this dependency have to exist - if not, ordering below must be specified
-    mandatory=true #mandatory
-    # The version range of the dependency
-    versionRange="[31,)" #mandatory
-    # An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
-    ordering="NONE"
-    # Side this dependency is applied on - BOTH, CLIENT or SERVER
-    side="BOTH"
-# Here's another dependency
-[[dependencies.examplemod]]
-    modId="minecraft"
-    mandatory=true
-    versionRange="[1.16.5]"
-    ordering="NONE"
-    side="BOTH"

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,7 +1,8 @@
 {
     "pack": {
         "description": "gdmc http interface resources",
-        "pack_format": 6,
-        "_comment": "A pack_format of 6 requires json lang files and some texture changes from 1.16.2. Note: we require v6 pack meta for all mods."
+        "pack_format": 9,
+        "forge:resource_pack_format": 9,
+        "forge:data_pack_format": 10
     }
 }


### PR DESCRIPTION
Addresses #1, updating the this mod to work for Minecraft 1.19.2.

Code behind the `/chunks` endpoint didn't change. Clients using this endpoint do however need to be changed to account for different data structure due to 3D biomes.