### PR TITLE
V1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
+# GDMC-HTTP 1.1.0 (Minecraft 1.19.2)
+
+- NEW: `POST /command` now accepts `x`, `y`, `z` parameters, usefull for when using commands with [relative coordinates](https://minecraft.fandom.com/wiki/Coordinates#Relative_world_coordinates) or commands such as [/locate](https://minecraft.fandom.com/wiki/Coordinates#Relative_world_coordinates).
+- NEW: Add `OPTIONS /` to get version of Minecraft and version of GDMC-HTTP interface.
+- NEW: Port number of the HTTP interface can be changed using the `/sethttpport <port>` Minecraft console command. This value will be saved to a config file and therefore will be persistent.
+- NEW: Get port number of the HTTP interface via the `/gethttpport` Minecraft console command.
+- FIX: The `/setbuildarea` console command can now also accept coordinates that aren't loaded yet.
+- FIX: Explicitly set HTTP interface address to that of the "loop back" address, which is usually "localhost".
+
 # GDMC-HTTP 1.0.0 (Minecraft 1.19.2)
+
 - BREAKING: JSON-formatted NBT-like data is no longer supported in request bodies. Use [SNBT notation](https://minecraft.fandom.com/wiki/NBT_format#SNBT_format) instead.
 - BREAKING: Properties containing NBT values in JSON responses are no longer formatted as JSON, but as [SNBT strings](https://minecraft.fandom.com/wiki/NBT_format#SNBT_format).
 - BREAKING: Plain-text formatted responses have been removed in favour of JSON.
@@ -7,10 +17,12 @@
 - FIX: Improved performance!
 
 # GDMC-HTTP 0.7.6 (Minecraft 1.19.2)
+
 - FIX: `GET /biomes` now returns an empty string for the biome ID if the requested position is outside of the vertical boundaries of the world.
 - FIX: Typo in error message `POST /structure` handler.
 
 # GDMC-HTTP 0.7.5 (Minecraft 1.19.2)
+
 - NEW: `GET /entities` for reading entities within a certain area.
 - NEW: `PUT /entities` for creating any number of entities.
 - NEW: `PATCH /entities` for editing existing entities in the world.
@@ -20,18 +32,23 @@
 - FIX: Partial refactor for improved readability and decreased branching.
 
 # GDMC-HTTP 0.7.4 (Minecraft 1.19.2)
+
 - FIX: Placement of multi-part blocks such as beds and doors.
 
 # GDMC-HTTP 0.7.3 (Minecraft 1.19.2)
+
 - NEW: Improved user-facing documentation.
 
 # GDMC-HTTP 0.7.2 (Minecraft 1.19.2)
+
 - FIX: Add proper exception handling for malformed JSON input at `PUT /blocks`.
 
 # GDMC-HTTP 0.7.1 (Minecraft 1.19.2)
+
 - FIX: Allow endpoint `PUT /blocks` to process block placement instructions without (valid) coordinates. It places it at the URL query coordinates instead.
 
 # GDMC-HTTP 0.7.0 (Minecraft 1.19.2)
+
 - NEW:`PUT /blocks` endpoint can now accept a JSON-formatted request body as input using the request header `"Content-Type": "application/json"`. The format is identical the response of the `GET /blocks` with the `"Accept": "application/json"` request header, with a few minor additional features:
   - For each placement instruction, `x`, `y` and `z` are optional. If omitted, it uses the coordinate set in the request's URL query as a fallback, or 0 if these aren't set.
   - For each placement instruction, `x`, `y` and `z` can be a integer ("x": `32`) or use tilde (`"x": "~32"`) or caret (`"x": "^32"`) notation in a string.
@@ -48,23 +65,29 @@
 - FIX: Minor improvements to performance.
 
 # GDMC-HTTP 0.6.5 (Minecraft 1.19.2)
+
 - NEW: Add `GET /structure` endpoint, for generating an NBT-formatted file of an area of blocks in the world.
 - NEW: Add `POST /structure` endpoint, for placing an NBT-formatted file of a structure into the world.
 
 # GDMC-HTTP 0.6.4 (Minecraft 1.19.2)
+
 - NEW: Enable `GET /chunks` to return a JSON-formatted response when the request header `Accept` is set to `application/json`.
 
 # GDMC-HTTP 0.6.3 (Minecraft 1.19.2)
+
 - NEW: Allow negative values for range coordinates in all endpoints that take the `dx`, `dy` and `dz` parameters.
 
 # GDMC-HTTP 0.6.2 (Minecraft 1.19.2)
+
 - FIX: Fixed formatting coordinates in plain-text response for `GET /blocks` endpoint.
 
 # GDMC-HTTP 0.6.1 (Minecraft 1.19.2)
+
 - NEW: Add `GET /biomes` endpoint to request biome of a location in the world.
 - FIX: Minor performance improvements.
 
 # GDMC-HTTP 0.6.0 (Minecraft 1.19.2)
+
 - NEW: `PUT /blocks` can now also process block entity data (eg. chest contents, a book on a lectern, armor on an armor stand, etc.).
 - NEW: `GET /blocks` can return multiple blocks within a given area.
 - NEW: Response of `GET /blocks` now always includes a block's position in front of its material.
@@ -75,17 +98,21 @@
 - FIX: Minor performance improvements.
 
 # GDMC-HTTP 0.5.3 (Minecraft 1.19.2)
+
 - NEW: Implement parameter for specify target dimension (overworld, nether, end, etc.) for the `/blocks`, `/command` and `/chunks` endpoints. For example `PUT /blocks?dimension=nether` places blocks in the nether instead of the overworld. If parameter is omitted it defaults to the overworld.
 - NEW: Implement `OPTIONS` method for the `/blocks` endpoint.
 - FIX: Relative position placement for blocks with a `~<int>` position when placing blocks with the `PUT /blocks` endpoint.
 
 # GDMC-HTTP 0.5.2 (Minecraft 1.19.2)
+
 - BREAKING: Renamed `GET /info` endpoint to `GET /version`.
 
 # GDMC-HTTP 0.5.1 (Minecraft 1.19.2)
+
 - NEW: Add `GET /info` endpoint, to get the current Minecraft version.
 
 # GDMC-HTTP 0.5.0 (Minecraft 1.19.2)
+
 - NEW: Compatibility with Minecraft version 1.19.2.
 - BREAKING: No longer compatible with versions of Minecraft other than 1.19.2.
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'net.minecraftforge.gradle' version '5.1.+'
 }
 
-version = '1.0.0'
+version = '1.1.0'
 group = 'com.nilsgawlik.gdmchttp' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'gdmchttp'
 

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -855,3 +855,38 @@ Plain-text response with the Minecraft version number.
 ```
 1.19.2
 ```
+
+# Read HTTP interface information `OPTIONS /`
+
+Get the information about GDMC HTTP itself.
+
+## URL parameters
+
+None
+
+## Request headers
+
+None
+
+## Request body
+
+N/A
+
+## Response headers
+
+[Default](#Response-headers)
+
+## Response body
+
+JSON object containing the following:
+- `minecraftVersion`
+- `interfaceVersion`
+
+## Example
+
+```json
+{
+  "minecraftVersion": "1.19.2",
+  "interfaceVersion": "1.1.0"
+}
+```

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -40,9 +40,12 @@ Send one or more Minecraft console commands to the server. For the full list of 
 
 ## URL parameters
 
-| key       | valid values                                          | required | defaults to | description                                                            |
-|-----------|-------------------------------------------------------|----------|-------------|------------------------------------------------------------------------|
-| dimension | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       | `overworld` | Sets in which dimension of the world the commands will be executed in. |
+| key       | valid values                                          | required | defaults to | description                                                                    |
+|-----------|-------------------------------------------------------|----------|-------------|--------------------------------------------------------------------------------|
+| x         | integer                                               | no       | `0`         | X coordinate of command source. For commands that work with relative position. |
+| y         | integer                                               | no       | `0`         | Y coordinate of command source. For commands that work with relative position. |
+| z         | integer                                               | no       | `0`         | Z coordinate of command source. For commands that work with relative position. |
+| dimension | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       | `overworld` | Sets in which dimension of the world the commands will be executed in.         |
 
 ## Request headers
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -3,3 +3,14 @@
 Since the interface this mod provides uses HTTP, any program or language that has a component capable of doing HTTP requests can be a client. [GDPC](https://github.com/avdstaaij/gdpc) is a Python solution specifically designed for the purpose of generative design in Minecraft and is recommended to beginners, but you can write your own client in any programming language you like. You can find an example on how to provide access to the interface endpoints in your own client [here](https://github.com/avdstaaij/gdpc/blob/master/gdpc/direct_interface.py). For debugging and experimenting without writing your own program an API exploration tool such as [Insomnia](https://insomnia.rest/) or [Postman](https://www.postman.com/) is recommended.
 
 Go [here](./Endpoints.md) for full documentation on how all the endpoints work.
+
+## Commands
+This mod adds a few new console commands to Minecraft
+
+- `/setbuildarea <fromX> <fromY> <fromZ> <toX> <toY> <toZ>`
+  - Sets a build area which can be referred to using the [GET /buildarea](docs/Endpoints.md:788) endpoint
+  - Example `/setbuildarea ~ ~ ~ ~100 ~40 ~100`
+- `/sethttpport <number>`
+  - Changes the port number the HTTP interface can be reached from. Only comes into effect when Minecraft world is reloaded.
+- `/gethttpport`
+  - Shows the port the HTTP interface can be reached from.

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpMod.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpMod.java
@@ -35,6 +35,8 @@ public class GdmcHttpMod
         RegistryHandler.registerCommands(event);
         MinecraftServer minecraftServer = event.getServer();
 
+        // TODO load port number from settings file
+
         try {
             GdmcHttpServer.startServer(minecraftServer);
             minecraftServer.sendSystemMessage(Component.nullToEmpty("GDMC Server started successfully."));

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpMod.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpMod.java
@@ -1,5 +1,6 @@
 package com.gdmc.httpinterfacemod;
 
+import com.gdmc.httpinterfacemod.config.GdmcHttpConfig;
 import com.gdmc.httpinterfacemod.utils.RegistryHandler;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
@@ -7,7 +8,9 @@ import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.event.server.ServerStoppingEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.config.ModConfig;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,6 +26,7 @@ public class GdmcHttpMod
     private static final Logger LOGGER = LogManager.getLogger();
 
     public GdmcHttpMod() {
+        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, GdmcHttpConfig.SPEC, "gdmc-http-interface-common.toml");
         // Register ourselves for server and other game events we are interested in
         MinecraftForge.EVENT_BUS.register(this);
     }
@@ -32,10 +36,9 @@ public class GdmcHttpMod
     public void onServerStarting(ServerStartingEvent event) {
         // do something when the server starts
         LOGGER.info("Server starting");
+
         RegistryHandler.registerCommands(event);
         MinecraftServer minecraftServer = event.getServer();
-
-        // TODO load port number from settings file
 
         try {
             GdmcHttpServer.startServer(minecraftServer);

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
@@ -1,5 +1,6 @@
 package com.gdmc.httpinterfacemod;
 
+import com.gdmc.httpinterfacemod.config.GdmcHttpConfig;
 import com.gdmc.httpinterfacemod.handlers.*;
 import com.sun.net.httpserver.HttpServer;
 import net.minecraft.server.MinecraftServer;
@@ -11,16 +12,24 @@ public class GdmcHttpServer {
     private static HttpServer httpServer;
     private static MinecraftServer mcServer;
 
+    public static int getHttpServerPortConfig() {
+        return GdmcHttpConfig.HTTP_INTERFACE_PORT.get();
+    }
+    public static void setHttpServerPortConfig(int portNumber) {
+        GdmcHttpConfig.HTTP_INTERFACE_PORT.set(portNumber);
+    }
+
+    public static int getCurrentHttpPort() {
+        return httpServer.getAddress().getPort();
+    }
     public static void startServer(MinecraftServer mcServer) throws IOException {
         if (GdmcHttpServer.mcServer != mcServer) {
             GdmcHttpServer.mcServer = mcServer;
         }
-        startServer(9000);
+        startServer(getHttpServerPortConfig());
     }
 
     public static void startServer(int portNumber) throws IOException {
-
-
         // Stop server if one was already running
         stopServer();
 
@@ -28,6 +37,9 @@ public class GdmcHttpServer {
         httpServer.setExecutor(null); // creates a default executor
         createContexts();
         httpServer.start();
+
+        // Update mod config file
+        setHttpServerPortConfig(portNumber);
     }
 
     public static void stopServer() {

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
@@ -6,6 +6,7 @@ import com.sun.net.httpserver.HttpServer;
 import net.minecraft.server.MinecraftServer;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 
 public class GdmcHttpServer {
@@ -27,7 +28,9 @@ public class GdmcHttpServer {
     }
 
     public static void startServer(int portNumber) throws IOException {
-        httpServer = HttpServer.create(new InetSocketAddress(portNumber), 0);
+        // Create HTTP server on localhost with the port number defined in the config file.
+        InetAddress localHost = InetAddress.getLoopbackAddress();
+        httpServer = HttpServer.create(new InetSocketAddress(localHost, portNumber), 0);
         httpServer.setExecutor(null); // creates a default executor
         createContexts();
         httpServer.start();

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
@@ -12,17 +12,27 @@ public class GdmcHttpServer {
     private static MinecraftServer mcServer;
 
     public static void startServer(MinecraftServer mcServer) throws IOException {
-        GdmcHttpServer.mcServer = mcServer;
+        if (GdmcHttpServer.mcServer != mcServer) {
+            GdmcHttpServer.mcServer = mcServer;
+        }
+        startServer(9000);
+    }
 
-        httpServer = HttpServer.create(new InetSocketAddress(9000), 0);
+    public static void startServer(int portNumber) throws IOException {
+
+
+        // Stop server if one was already running
+        stopServer();
+
+        httpServer = HttpServer.create(new InetSocketAddress(portNumber), 0);
         httpServer.setExecutor(null); // creates a default executor
         createContexts();
         httpServer.start();
     }
 
     public static void stopServer() {
-        if(httpServer != null) {
-            httpServer.stop(5);
+        if (httpServer != null) {
+            httpServer.stop(0);
         }
     }
 

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
@@ -35,5 +35,6 @@ public class GdmcHttpServer {
         httpServer.createContext("/biomes", new BiomesHandler(mcServer));
         httpServer.createContext("/structure", new StructureHandler(mcServer));
         httpServer.createContext("/entities", new EntitiesHandler(mcServer));
+        httpServer.createContext("/", new InterfaceInfoHandler(mcServer));
     }
 }

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
@@ -15,13 +15,10 @@ public class GdmcHttpServer {
     public static int getHttpServerPortConfig() {
         return GdmcHttpConfig.HTTP_INTERFACE_PORT.get();
     }
-    public static void setHttpServerPortConfig(int portNumber) {
-        GdmcHttpConfig.HTTP_INTERFACE_PORT.set(portNumber);
-    }
-
     public static int getCurrentHttpPort() {
         return httpServer.getAddress().getPort();
     }
+
     public static void startServer(MinecraftServer mcServer) throws IOException {
         if (GdmcHttpServer.mcServer != mcServer) {
             GdmcHttpServer.mcServer = mcServer;
@@ -30,21 +27,15 @@ public class GdmcHttpServer {
     }
 
     public static void startServer(int portNumber) throws IOException {
-        // Stop server if one was already running
-        stopServer();
-
         httpServer = HttpServer.create(new InetSocketAddress(portNumber), 0);
         httpServer.setExecutor(null); // creates a default executor
         createContexts();
         httpServer.start();
-
-        // Update mod config file
-        setHttpServerPortConfig(portNumber);
     }
 
     public static void stopServer() {
         if (httpServer != null) {
-            httpServer.stop(0);
+            httpServer.stop(5);
         }
     }
 

--- a/src/main/java/com/gdmc/httpinterfacemod/commands/GetHttpInterfacePort.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/commands/GetHttpInterfacePort.java
@@ -1,0 +1,29 @@
+package com.gdmc.httpinterfacemod.commands;
+
+import com.gdmc.httpinterfacemod.GdmcHttpServer;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+public class GetHttpInterfacePort {
+
+	private static final String COMMAND_NAME = "gethttpport";
+	private GetHttpInterfacePort() {}
+
+	public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+		dispatcher.register(
+			Commands.literal(COMMAND_NAME)
+			.executes(context -> perform(context))
+		);
+	}
+
+	private static int perform(CommandContext<CommandSourceStack> commandSourceContext) {
+		int currentPort = GdmcHttpServer.getCurrentHttpPort();
+		commandSourceContext.getSource().sendSuccess(Component.nullToEmpty(
+			String.valueOf(currentPort)
+		), true);
+		return currentPort;
+	}
+}

--- a/src/main/java/com/gdmc/httpinterfacemod/commands/SetBuildAreaCommand.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/commands/SetBuildAreaCommand.java
@@ -1,4 +1,4 @@
-package com.gdmc.httpinterfacemod.settlementcommand;
+package com.gdmc.httpinterfacemod.commands;
 
 import com.gdmc.httpinterfacemod.handlers.BuildAreaHandler;
 import com.mojang.brigadier.CommandDispatcher;
@@ -11,7 +11,7 @@ import net.minecraft.network.chat.Component;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class SetBuildAreaCommand<S> {
+public final class SetBuildAreaCommand {
 
     private static final String COMMAND_NAME = "setbuildarea";
     private static final Logger LOGGER = LogManager.getLogger();
@@ -19,13 +19,15 @@ public class SetBuildAreaCommand<S> {
     private SetBuildAreaCommand() { }
 
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
-        dispatcher.register(
-                Commands.literal(COMMAND_NAME)
-                .then(Commands.argument("from", BlockPosArgument.blockPos())
-                .then(Commands.argument("to", BlockPosArgument.blockPos())
-                .executes( context -> {
-                    return perform(context, BlockPosArgument.getLoadedBlockPos(context, "from"), BlockPosArgument.getLoadedBlockPos(context, "to"));
-                }))));
+        dispatcher.register(Commands.literal(COMMAND_NAME)
+            .then(
+                Commands.argument("from", BlockPosArgument.blockPos())
+            .then(
+                Commands.argument("to", BlockPosArgument.blockPos())
+            .executes( context -> perform(context, BlockPosArgument.getLoadedBlockPos(context, "from"), BlockPosArgument.getLoadedBlockPos(context, "to"))))
+            )
+        );
+        // TODO remove requirement of the position to be loaded
     }
 
     private static int perform(CommandContext<CommandSourceStack> commandSourceContext, BlockPos from, BlockPos to) {

--- a/src/main/java/com/gdmc/httpinterfacemod/commands/SetBuildAreaCommand.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/commands/SetBuildAreaCommand.java
@@ -6,15 +6,13 @@ import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.coordinates.BlockPosArgument;
+import net.minecraft.commands.arguments.coordinates.Coordinates;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 public final class SetBuildAreaCommand {
 
     private static final String COMMAND_NAME = "setbuildarea";
-    private static final Logger LOGGER = LogManager.getLogger();
 
     private SetBuildAreaCommand() { }
 
@@ -24,10 +22,12 @@ public final class SetBuildAreaCommand {
                 Commands.argument("from", BlockPosArgument.blockPos())
             .then(
                 Commands.argument("to", BlockPosArgument.blockPos())
-            .executes( context -> perform(context, BlockPosArgument.getLoadedBlockPos(context, "from"), BlockPosArgument.getLoadedBlockPos(context, "to"))))
-            )
+            .executes( context -> perform(
+                context,
+                context.getArgument("from", Coordinates.class).getBlockPos(context.getSource()),
+                context.getArgument("to", Coordinates.class).getBlockPos(context.getSource())
+            ))))
         );
-        // TODO remove requirement of the position to be loaded
     }
 
     private static int perform(CommandContext<CommandSourceStack> commandSourceContext, BlockPos from, BlockPos to) {
@@ -41,7 +41,6 @@ public final class SetBuildAreaCommand {
         BuildAreaHandler.setBuildArea(x1, y1, z1, x2, y2, z2);
         String feedback = String.format("Build area set to %d, %d, %d to %d, %d, %d,", x1, y1, z1, x2, y2, z2 );
         commandSourceContext.getSource().sendSuccess(Component.nullToEmpty(feedback), true);
-        LOGGER.info(feedback);
         return 1;
     }
 }

--- a/src/main/java/com/gdmc/httpinterfacemod/commands/SetHttpInterfacePort.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/commands/SetHttpInterfacePort.java
@@ -1,0 +1,49 @@
+package com.gdmc.httpinterfacemod.commands;
+
+import com.gdmc.httpinterfacemod.GdmcHttpServer;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+
+public final class SetHttpInterfacePort {
+
+	private static final String COMMAND_NAME = "sethttpport";
+
+	private static final Logger LOGGER = LogManager.getLogger();
+
+	private SetHttpInterfacePort() {}
+
+	public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+		dispatcher.register(
+			Commands.literal(COMMAND_NAME)
+			.then(Commands.argument("port", IntegerArgumentType.integer(0, 65535))
+			.executes(context -> perform(context, IntegerArgumentType.getInteger(context, "port")))
+		));
+	}
+
+	private static int perform(CommandContext<CommandSourceStack> commandSourceContext, int newPortNumber) {
+		LOGGER.info(newPortNumber);
+
+		try {
+			GdmcHttpServer.startServer(newPortNumber);
+			commandSourceContext.getSource().sendSuccess(Component.nullToEmpty(
+				String.format("Port changed to %s", newPortNumber)
+			), true);
+		} catch (IOException e) {
+			LOGGER.error(e.getStackTrace());
+			commandSourceContext.getSource().sendFailure(Component.nullToEmpty(
+				String.format("Cannot change port number to %s: %s", newPortNumber, e.getMessage())
+			));
+			throw new RuntimeException(e);
+		}
+
+		return 1;
+	}
+}

--- a/src/main/java/com/gdmc/httpinterfacemod/commands/SetHttpInterfacePort.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/commands/SetHttpInterfacePort.java
@@ -7,16 +7,12 @@ import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 
 public final class SetHttpInterfacePort {
 
 	private static final String COMMAND_NAME = "sethttpport";
-
-	private static final Logger LOGGER = LogManager.getLogger();
 
 	private SetHttpInterfacePort() {}
 
@@ -29,21 +25,17 @@ public final class SetHttpInterfacePort {
 	}
 
 	private static int perform(CommandContext<CommandSourceStack> commandSourceContext, int newPortNumber) {
-		LOGGER.info(newPortNumber);
-
 		try {
 			GdmcHttpServer.startServer(newPortNumber);
 			commandSourceContext.getSource().sendSuccess(Component.nullToEmpty(
 				String.format("Port changed to %s", newPortNumber)
 			), true);
 		} catch (IOException e) {
-			LOGGER.error(e.getStackTrace());
 			commandSourceContext.getSource().sendFailure(Component.nullToEmpty(
 				String.format("Cannot change port number to %s: %s", newPortNumber, e.getMessage())
 			));
 			throw new RuntimeException(e);
 		}
-
-		return 1;
+		return newPortNumber;
 	}
 }

--- a/src/main/java/com/gdmc/httpinterfacemod/commands/SetHttpInterfacePort.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/commands/SetHttpInterfacePort.java
@@ -1,14 +1,12 @@
 package com.gdmc.httpinterfacemod.commands;
 
-import com.gdmc.httpinterfacemod.GdmcHttpServer;
+import com.gdmc.httpinterfacemod.config.GdmcHttpConfig;
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
-
-import java.io.IOException;
 
 public final class SetHttpInterfacePort {
 
@@ -26,15 +24,14 @@ public final class SetHttpInterfacePort {
 
 	private static int perform(CommandContext<CommandSourceStack> commandSourceContext, int newPortNumber) {
 		try {
-			GdmcHttpServer.startServer(newPortNumber);
+			GdmcHttpConfig.HTTP_INTERFACE_PORT.set(newPortNumber);
 			commandSourceContext.getSource().sendSuccess(Component.nullToEmpty(
-				String.format("Port changed to %s", newPortNumber)
+				String.format("Port changed to %s. Reload the world for it to take effect.", newPortNumber)
 			), true);
-		} catch (IOException e) {
+		} catch (IllegalArgumentException e) {
 			commandSourceContext.getSource().sendFailure(Component.nullToEmpty(
 				String.format("Cannot change port number to %s: %s", newPortNumber, e.getMessage())
 			));
-			throw new RuntimeException(e);
 		}
 		return newPortNumber;
 	}

--- a/src/main/java/com/gdmc/httpinterfacemod/config/GdmcHttpConfig.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/config/GdmcHttpConfig.java
@@ -1,0 +1,22 @@
+package com.gdmc.httpinterfacemod.config;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public class GdmcHttpConfig {
+
+	public static final ForgeConfigSpec.Builder BUILDER = new ForgeConfigSpec.Builder();
+	public static final ForgeConfigSpec SPEC;
+
+	public static final ForgeConfigSpec.ConfigValue<Integer> HTTP_INTERFACE_PORT;
+
+	static {
+		BUILDER.push("Config for GDMC HTTP Interface");
+
+		HTTP_INTERFACE_PORT = BUILDER.comment("Port number for HTTP interface").defineInRange("gdmc http port", 9000, 0, 65535);
+
+		BUILDER.pop();
+
+		SPEC = BUILDER.build();
+	}
+
+}

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/CommandHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/CommandHandler.java
@@ -7,6 +7,7 @@ import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.phys.Vec3;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -27,13 +28,26 @@ public class CommandHandler extends HandlerBase {
 
         Map<String, String> queryParams = parseQueryString(httpExchange.getRequestURI().getRawQuery());
 
-        String dimension = queryParams.getOrDefault("dimension", null);
+        // POST: x, y, z positions
+        int x;
+        int y;
+        int z;
+        String dimension;
+        try {
+            x = Integer.parseInt(queryParams.getOrDefault("x", "0"));
+            y = Integer.parseInt(queryParams.getOrDefault("y", "0"));
+            z = Integer.parseInt(queryParams.getOrDefault("z", "0"));
+
+            dimension = queryParams.getOrDefault("dimension", null);
+        } catch (NumberFormatException e) {
+            throw new HttpException("Could not parse query parameter: " + e.getMessage(), 400);
+        }
 
         // execute command(s)
         InputStream bodyStream = httpExchange.getRequestBody();
         List<String> commands = new BufferedReader(new InputStreamReader(bodyStream)).lines().toList();
 
-        CommandSourceStack cmdSrc = createCommandSource("GDMC-CommandHandler", dimension);
+        CommandSourceStack cmdSrc = createCommandSource("GDMC-CommandHandler", dimension, new Vec3(x, y, z));
 
         JsonArray returnValues = new JsonArray();
         for (String command: commands) {

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
@@ -238,6 +238,10 @@ public abstract class HandlerBase implements HttpHandler {
         return json;
     }
 
+    protected CommandSourceStack createCommandSource(String name, String dimension) {
+        return createCommandSource(name, dimension, new Vec3(0, 0, 0));
+    }
+
     /**
      * Helper to create a {@link CommandSourceStack}, which serves as the source to dispatch
      * commands from (See {@link CommandHandler}) or as a point of origin to place blocks
@@ -245,9 +249,10 @@ public abstract class HandlerBase implements HttpHandler {
      *
      * @param name          Some unique identifier.
      * @param dimension     The dimension (also known as level) in the world of {@code mcServer} in which the {@link CommandSourceStack} is going to be placed.
+     * @param pos           World position of the command source. Relevant for using relative coordinates and the /locate command.
      * @return              An instance of {@link CommandSourceStack}.
      */
-    protected CommandSourceStack createCommandSource(String name, String dimension) {
+    protected CommandSourceStack createCommandSource(String name, String dimension, Vec3 pos) {
         CommandSource commandSource = new CommandSource() {
             @Override
             public void sendSystemMessage(@NotNull Component p_230797_) {
@@ -272,7 +277,7 @@ public abstract class HandlerBase implements HttpHandler {
 
         return new CommandSourceStack(
             commandSource,
-            new Vec3(0, 0, 0),
+            pos,
             new Vec2(0, 0),
             this.getServerLevel(dimension),
             4,

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/InterfaceInfoHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/InterfaceInfoHandler.java
@@ -1,0 +1,32 @@
+package com.gdmc.httpinterfacemod.handlers;
+
+import com.google.gson.JsonObject;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import net.minecraft.server.MinecraftServer;
+
+import java.io.IOException;
+
+public class InterfaceInfoHandler extends HandlerBase {
+	public InterfaceInfoHandler(MinecraftServer mcServer) {
+		super(mcServer);
+	}
+
+	@Override
+	protected void internalHandle(HttpExchange httpExchange) throws IOException {
+		String method = httpExchange.getRequestMethod().toLowerCase();
+
+		if (!method.equals("options")) {
+			throw new HttpException("Method not allowed. Only GET requests are supported.", 405);
+		}
+
+		Headers responseHeaders = httpExchange.getResponseHeaders();
+		setDefaultResponseHeaders(responseHeaders);
+
+		JsonObject json = new JsonObject();
+		json.addProperty("minecraftVersion", mcServer.getServerVersion());
+		json.addProperty("interfaceVersion", "1.1.0");
+
+		resolveRequest(httpExchange, json.toString());
+	}
+}

--- a/src/main/java/com/gdmc/httpinterfacemod/utils/RegistryHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/utils/RegistryHandler.java
@@ -1,5 +1,6 @@
 package com.gdmc.httpinterfacemod.utils;
 
+import com.gdmc.httpinterfacemod.commands.GetHttpInterfacePort;
 import com.gdmc.httpinterfacemod.commands.SetBuildAreaCommand;
 import com.gdmc.httpinterfacemod.commands.SetHttpInterfacePort;
 import com.mojang.brigadier.CommandDispatcher;
@@ -12,5 +13,6 @@ public class RegistryHandler {
         CommandDispatcher<CommandSourceStack> dispatcher = event.getServer().getCommands().getDispatcher();
         SetBuildAreaCommand.register(dispatcher);
         SetHttpInterfacePort.register(dispatcher);
+        GetHttpInterfacePort.register(dispatcher);
     }
 }

--- a/src/main/java/com/gdmc/httpinterfacemod/utils/RegistryHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/utils/RegistryHandler.java
@@ -1,6 +1,7 @@
 package com.gdmc.httpinterfacemod.utils;
 
-import com.gdmc.httpinterfacemod.settlementcommand.SetBuildAreaCommand;
+import com.gdmc.httpinterfacemod.commands.SetBuildAreaCommand;
+import com.gdmc.httpinterfacemod.commands.SetHttpInterfacePort;
 import com.mojang.brigadier.CommandDispatcher;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraftforge.event.server.ServerStartingEvent;
@@ -8,12 +9,8 @@ import net.minecraftforge.event.server.ServerStartingEvent;
 public class RegistryHandler {
 
     public static void registerCommands(ServerStartingEvent event) {
-
-        // TODO might be wrong (didn't test)
         CommandDispatcher<CommandSourceStack> dispatcher = event.getServer().getCommands().getDispatcher();
         SetBuildAreaCommand.register(dispatcher);
-        // maybe try this instead:
-//        CommandDispatcher<CommandSource> dispatcher = event.getServer().getFunctionManager().getCommandDispatcher();
-//        BuildSettlementCommand.register(dispatcher);
+        SetHttpInterfacePort.register(dispatcher);
     }
 }


### PR DESCRIPTION
Changelog:

- [x] NEW: `POST /command` now accepts `x`, `y`, `z` parameters, usefull for when using commands with [relative coordinates](https://minecraft.fandom.com/wiki/Coordinates#Relative_world_coordinates) or commands such as [/locate](https://minecraft.fandom.com/wiki/Coordinates#Relative_world_coordinates).
- [x] NEW: Add `OPTIONS /` to get version of Minecraft and version of GDMC-HTTP interface.
- [x] NEW: Change HTTP port number via the `/sethttpport <port>` Minecraft console command. This value saved to a config file and therefore persistent.
- [x] NEW: Get HTTP port number via the `/gethttpport` Minecraft console command.
- [x] FIX: `/setbuildarea` can now include positions that aren't loaded yet.