### PR TITLE
V1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-# GDMC-HTTP 1.1.1 (Minecraft 1.19.2) 
+# GDMC-HTTP 1.2.0 (Minecraft 1.19.2)
+
+- NEW: Add `GET /players` endpoint to get all players on the server. Thanks to [cmoyates](https://github.com/cmoyates)!
+- NEW: Add support for [target selector](https://minecraft.fandom.com/wiki/Target_selectors) for entities in the `GET /entities` endpoint using the `selector` query parameter.
+- NEW: Add support for [target selector](https://minecraft.fandom.com/wiki/Target_selectors) for players in the `GET /players` endpoint using the `selector` query parameter.
+- NEW: Unset build area by entering the `/setbuildarea` command without arguments.
+
+# GDMC-HTTP 1.1.1 (Minecraft 1.19.2)
 
 - FIX: Undo explicitly setting HTTP interface address to the "loop back" address.
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repo is based on a fork of [Niki Gawlik's GDMC HTTP Interface](https://gith
 ## Features / HTTP Endpoints
 
 The current endpoints of the interface are:
+
 ```
 GET,PUT                 /blocks     Modify blocks in the world
 POST                    /command    Run Minecraft commands
@@ -24,6 +25,7 @@ GET,POST                /structure  Generate NBT structure file from selection o
 GET,PUT,PATCH,DELETE    /entities   Read, create, edit and remove entities from the world
 GET                     /buildarea  Get the build area defined by the /setbuildarea chat command
 GET                     /version    Get Minecraft version
+GET                     /players    Read players from the world
 ```
 
 A detailed documentation of the endpoints can be found [over here](./docs/Endpoints.md).

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'net.minecraftforge.gradle' version '5.1.+'
 }
 
-version = '1.1.1'
+version = '1.2.0'
 group = 'com.nilsgawlik.gdmchttp' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'gdmchttp'
 

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -600,17 +600,17 @@ Endpoint for reading all [entities](https://minecraft.fandom.com/wiki/Entity) fr
 
 ## URL parameters
 
-| key         | valid values                                          | required | defaults to                      | description                                                                                                          |
-|-------------|-------------------------------------------------------|----------|----------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| x           | integer                                               | no       | `0`                              | X coordinate                                                                                                         |
-| y           | integer                                               | no       | `0`                              | Y coordinate                                                                                                         |
-| z           | integer                                               | no       | `0`                              | Z coordinate                                                                                                         |
-| dx          | integer                                               | no       | `1`                              | Range of blocks to get counting from x (can be negative)                                                             |
-| dy          | integer                                               | no       | `1`                              | Range of blocks to get counting from y (can be negative)                                                             |
-| dz          | integer                                               | no       | `1`                              | Range of blocks to get counting from z (can be negative)                                                             |
-| selector    | target selector string                                | no       | `@e[x=0,y=0,z=0,xd=1,yd=1,dz=1]` | [Target selector](https://minecraft.fandom.com/wiki/Target_selectors) string for entities. This must be URL encoded. |
-| includeData | `true`, `false`                                       | no       | `false`                          | If `true`, include [entity data](https://minecraft.fandom.com/wiki/Entity_format#Entity_Format) in response          |
-| dimension   | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       | `overworld`                      | Which dimension of the world to read entities from                                                                   |
+| key         | valid values                                          | required | defaults to                      | description                                                                                                     |
+|-------------|-------------------------------------------------------|----------|----------------------------------|-----------------------------------------------------------------------------------------------------------------|
+| x           | integer                                               | no       | `0`                              | X coordinate (**deprecated**, use selector instead)                                                             |
+| y           | integer                                               | no       | `0`                              | Y coordinate (**deprecated**, use selector instead)                                                             |
+| z           | integer                                               | no       | `0`                              | Z coordinate (**deprecated**, use selector instead)                                                             |
+| dx          | integer                                               | no       | `1`                              | Range of blocks to get counting from x (can be negative) (**deprecated**, use selector instead)                 |
+| dy          | integer                                               | no       | `1`                              | Range of blocks to get counting from y (can be negative) (**deprecated**, use selector instead)                 |
+| dz          | integer                                               | no       | `1`                              | Range of blocks to get counting from z (can be negative) (**deprecated**, use selector instead)                 |
+| selector    | target selector string                                | no       | `@e[x=0,y=0,z=0,xd=1,yd=1,dz=1]` | [Target selector](https://minecraft.fandom.com/wiki/Target_selectors) string for entities. Must be URL-encoded. |
+| includeData | `true`, `false`                                       | no       | `false`                          | If `true`, include [entity data](https://minecraft.fandom.com/wiki/Entity_format#Entity_Format) in response     |
+| dimension   | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       | `overworld`                      | Which dimension of the world to read entities from.                                                             |
 
 ## Request headers
 
@@ -810,7 +810,7 @@ Endpoint for reading all [players](https://minecraft.fandom.com/wiki/Player) fro
 | key         | valid values                                          | required | defaults to | description                                                                                                                                                                                      |
 |-------------|-------------------------------------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | includeData | `true`, `false`                                       | no       | `false`     | If `true`, include [player data](https://minecraft.fandom.com/wiki/Player.dat_format#NBT_structure) in response                                                                                  |
-| selector    | target selector string                                | no       | `@a`        | [Target selector](https://minecraft.fandom.com/wiki/Target_selectors) string for players. This must be URL encoded.                                                                              |
+| selector    | target selector string                                | no       | `@a`        | [Target selector](https://minecraft.fandom.com/wiki/Target_selectors) string for players. Must be URL-encoded.                                                                                   |
 | dimension   | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       |             | Which dimension of the world get the list of players from. This is only relevant when using positional arguments as part of the target selector query. Otherwise this parameter will be ignored. |
 
 ## Request headers

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -600,16 +600,17 @@ Endpoint for reading all [entities](https://minecraft.fandom.com/wiki/Entity) fr
 
 ## URL parameters
 
-| key         | valid values                                          | required | defaults to | description                                                                                                 |
-|-------------|-------------------------------------------------------|----------|-------------|-------------------------------------------------------------------------------------------------------------|
-| x           | integer                                               | yes      | `0`         | X coordinate                                                                                                |
-| y           | integer                                               | yes      | `0`         | Y coordinate                                                                                                |
-| z           | integer                                               | yes      | `0`         | Z coordinate                                                                                                |
-| dx          | integer                                               | no       | `1`         | Range of blocks to get counting from x (can be negative)                                                    |
-| dy          | integer                                               | no       | `1`         | Range of blocks to get counting from y (can be negative)                                                    |
-| dz          | integer                                               | no       | `1`         | Range of blocks to get counting from z (can be negative)                                                    |
-| includeData | `true`, `false`                                       | no       | `false`     | If `true`, include [entity data](https://minecraft.fandom.com/wiki/Entity_format#Entity_Format) in response |
-| dimension   | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       | `overworld` | Which dimension of the world to read entities from                                                          |
+| key         | valid values                                          | required | defaults to                      | description                                                                                                          |
+|-------------|-------------------------------------------------------|----------|----------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| x           | integer                                               | no       | `0`                              | X coordinate                                                                                                         |
+| y           | integer                                               | no       | `0`                              | Y coordinate                                                                                                         |
+| z           | integer                                               | no       | `0`                              | Z coordinate                                                                                                         |
+| dx          | integer                                               | no       | `1`                              | Range of blocks to get counting from x (can be negative)                                                             |
+| dy          | integer                                               | no       | `1`                              | Range of blocks to get counting from y (can be negative)                                                             |
+| dz          | integer                                               | no       | `1`                              | Range of blocks to get counting from z (can be negative)                                                             |
+| selector    | target selector string                                | no       | `@e[x=0,y=0,z=0,xd=1,yd=1,dz=1]` | [Target selector](https://minecraft.fandom.com/wiki/Target_selectors) string for entities. This must be URL encoded. |
+| includeData | `true`, `false`                                       | no       | `false`                          | If `true`, include [entity data](https://minecraft.fandom.com/wiki/Entity_format#Entity_Format) in response          |
+| dimension   | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       | `overworld`                      | Which dimension of the world to read entities from                                                                   |
 
 ## Request headers
 
@@ -643,6 +644,20 @@ Given a pit with 3 cats in it, the request `GET /entities?x=305&y=65&z=26&dx=10&
 ]
 ```
 This area happens to contain a wandering trader and their trusty lama.
+
+For a pen of various different farm animals of the size of 10 blocks wide and 10 blocks deep, using `@e[type=sheep]` as part of the request will return 2 sheep in this area. `GET /entities?includeData=true&selector=%40e%5Btype%3Dsheep,x%3D-20,y%3D0,z%3D-21,dx%3D10,dy%3D10,dz%3D10%5D`:
+```json
+[
+	{
+		"uuid": "8dd55c24-6474-409c-8e20-03162bca51a3",
+		"data": "{AbsorptionAmount:0.0f,Age:0,Air:300s,ArmorDropChances:[0.085f,0.085f,0.085f,0.085f],ArmorItems:[{},{},{},{}],Attributes:[{Base:0.23000000417232513d,Name:\"minecraft:generic.movement_speed\"},{Base:0.08d,Name:\"forge:entity_gravity\"},{Base:16.0d,Modifiers:[{Amount:-0.07929991095224685d,Name:\"Random spawn bonus\",Operation:1,UUID:[I;1067948072,-308262071,-1111740963,1312757403]},{Amount:-0.03951824343984822d,Name:\"Random spawn bonus\",Operation:1,UUID:[I;740224470,1022511074,-1558286765,872046470]}],Name:\"minecraft:generic.follow_range\"},{Base:0.0d,Name:\"minecraft:generic.armor_toughness\"},{Base:0.0d,Name:\"forge:step_height_addition\"},{Base:0.0d,Name:\"minecraft:generic.attack_knockback\"},{Base:8.0d,Name:\"minecraft:generic.max_health\"},{Base:0.0d,Name:\"minecraft:generic.knockback_resistance\"},{Base:0.0d,Name:\"minecraft:generic.armor\"}],Brain:{memories:{}},CanPickUpLoot:0b,CanUpdate:1b,Color:0b,DeathTime:0s,FallDistance:0.0f,FallFlying:0b,Fire:-1s,ForcedAge:0,HandDropChances:[0.085f,0.085f],HandItems:[{},{}],Health:8.0f,HurtByTimestamp:0,HurtTime:0s,InLove:0,Invulnerable:0b,LeftHanded:0b,Motion:[0.0d,-0.0784000015258789d,0.0d],OnGround:1b,PersistenceRequired:1b,PortalCooldown:0,Pos:[-17.443500798782093d,1.0d,-16.3957606052768d],Rotation:[4.6664124f,0.0f],Sheared:0b,UUID:[I;-1915397084,1685340316,-1910504682,734679459],id:\"minecraft:sheep\"}"
+	},
+	{
+		"uuid": "758a4369-0df1-4784-aea8-3db04970b68c",
+		"data": "{AbsorptionAmount:0.0f,Age:0,Air:300s,ArmorDropChances:[0.085f,0.085f,0.085f,0.085f],ArmorItems:[{},{},{},{}],Attributes:[{Base:0.23000000417232513d,Name:\"minecraft:generic.movement_speed\"},{Base:0.08d,Name:\"forge:entity_gravity\"},{Base:16.0d,Modifiers:[{Amount:-0.054645176271711594d,Name:\"Random spawn bonus\",Operation:1,UUID:[I;452273734,1153713910,-1393383184,760955385]},{Amount:0.03129074760589258d,Name:\"Random spawn bonus\",Operation:1,UUID:[I;114520113,359677977,-1350020086,1661730340]}],Name:\"minecraft:generic.follow_range\"},{Base:0.0d,Name:\"minecraft:generic.armor_toughness\"},{Base:0.0d,Name:\"forge:step_height_addition\"},{Base:0.0d,Name:\"minecraft:generic.attack_knockback\"},{Base:8.0d,Name:\"minecraft:generic.max_health\"},{Base:0.0d,Name:\"minecraft:generic.knockback_resistance\"},{Base:0.0d,Name:\"minecraft:generic.armor\"}],Brain:{memories:{}},CanPickUpLoot:0b,CanUpdate:1b,Color:0b,DeathTime:0s,FallDistance:0.0f,FallFlying:0b,Fire:-1s,ForcedAge:0,HandDropChances:[0.085f,0.085f],HandItems:[{},{}],Health:8.0f,HurtByTimestamp:0,HurtTime:0s,InLove:0,Invulnerable:0b,LeftHanded:0b,Motion:[0.0d,-0.0784000015258789d,0.0d],OnGround:1b,PersistenceRequired:1b,PortalCooldown:0,Pos:[-16.02778909851362d,1.0d,-15.411003372310615d],Rotation:[249.61398f,0.0f],Sheared:0b,UUID:[I;1971995497,233916292,-1364705872,1232123532],id:\"minecraft:sheep\"}"
+	}
+]
+```
 
 # Create entities `PUT /entities`
 

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -18,7 +18,7 @@ The following error codes can occur at any endpoint:
 
 ## Request headers
 
-The requests headers for all endpoints are the followingen, unless stated otherwise.
+The requests headers for all endpoints are the following, unless stated otherwise.
 
 | key          | valid values       | defaults to        | description                                                                                               |
 |--------------|--------------------|--------------------|-----------------------------------------------------------------------------------------------------------|
@@ -889,4 +889,45 @@ JSON object containing the following:
   "minecraftVersion": "1.19.2",
   "interfaceVersion": "1.1.0"
 }
+```
+
+# Read players `GET /players`
+
+Endpoint for reading all [players](https://minecraft.fandom.com/wiki/Player) from the world.
+
+## URL parameters
+
+
+| key         | valid values                                          | required | defaults to | description                                                                                                 |
+|-------------|-------------------------------------------------------|----------|-------------|-------------------------------------------------------------------------------------------------------------|
+| includeData | `true`, `false`                                       | no       | `false`     | If `true`, include [player data](https://minecraft.fandom.com/wiki/Player.dat_format#NBT_structure) in response |
+
+
+## Request headers
+
+[Default](#Request-headers)
+
+## Request body
+
+N/A
+
+## Response headers
+
+[Default](#Response-headers)
+
+## Response body
+
+The response should follow this [schema](./schema.players.get.json).
+
+## Example
+
+Given a world with 1 player named "Dev" in it, request `GET /players?includeData=true`:
+
+```json
+[
+  {
+    "name": "Dev",
+    "data": "{AbsorptionAmount:0.0f,Air:300s,Attributes:[{Base:0.0d,Name:\"forge:step_height_addition\"},{Base:0.10000000149011612d,Name:\"minecraft:generic.movement_speed\"},{Base:0.08d,Name:\"forge:entity_gravity\"}],Brain:{memories:{}},CanUpdate:1b,DataVersion:3120,DeathTime:0s,Dimension:\"minecraft:overworld\",EnderItems:[],FallDistance:0.0f,FallFlying:0b,Fire:-20s,Health:20.0f,HurtByTimestamp:0,HurtTime:0s,Inventory:[{Count:1b,Slot:0b,id:\"minecraft:obsidian\"},{Count:1b,Slot:1b,id:\"minecraft:flint_and_steel\",tag:{Damage:0}}],Invulnerable:0b,Motion:[0.0d,0.0d,0.0d],OnGround:0b,PortalCooldown:0,Pos:[-3.483559135420974d,-58.74889429576954d,-16.579720966624766d],Rotation:[1.6493444f,24.599985f],Score:0,SelectedItemSlot:1,SleepTimer:0s,UUID:[I;940439953,-167562164,-1601161573,-1389718966],XpLevel:0,XpP:0.0f,XpSeed:-275312302,XpTotal:0,abilities:{flySpeed:0.05f,flying:1b,instabuild:1b,invulnerable:1b,mayBuild:1b,mayfly:1b,walkSpeed:0.1f},foodExhaustionLevel:0.0f,foodLevel:20,foodSaturationLevel:5.0f,foodTickTimer:0,playerGameType:1,recipeBook:{isBlastingFurnaceFilteringCraftable:0b,isBlastingFurnaceGuiOpen:0b,isFilteringCraftable:0b,isFurnaceFilteringCraftable:0b,isFurnaceGuiOpen:0b,isGuiOpen:0b,isSmokerFilteringCraftable:0b,isSmokerGuiOpen:0b,recipes:[\"minecraft:flint_and_steel\",\"minecraft:enchanting_table\"],toBeDisplayed:[\"minecraft:flint_and_steel\",\"minecraft:enchanting_table\"]},seenCredits:0b,warden_spawn_tracker:{cooldown_ticks:0,ticks_since_last_warning:8788,warning_level:0}}"
+  }
+]
 ```

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -32,7 +32,7 @@ The responses for all endpoints return with the following headers, unless stated
 |-----------------------------|-----------------------------------|-------------|
 | Access-Control-Allow-Origin | `*`                               |             |
 | Content-Disposition         | `inline`                          |             |
-| Content-Type                | `application/json; charset=UTF-8` |             |  
+| Content-Type                | `application/json; charset=UTF-8` |             |
 
 # Send Commands `POST /commands`
 
@@ -262,7 +262,7 @@ To get information such as the contents of a chest, use `includeData=true` as pa
   }
 ]
 ```
-Note that that block data such as the contents of a chest are formatted as an [SNBT string](https://minecraft.fandom.com/wiki/NBT_format#SNBT_format). 
+Note that that block data such as the contents of a chest are formatted as an [SNBT string](https://minecraft.fandom.com/wiki/NBT_format#SNBT_format).
 
 # Place blocks `PUT /blocks`
 
@@ -369,7 +369,7 @@ This returns:
 ]
 ```
 
-Where each entry corresponds to a placement instruction, where `"status": 1` indicates a success, `"status": 0` that a block of that type is already there. This zero status may also appear when something else went wrong, such as when an invalid block ID was given. In such cases there also be a `"message"` attribute with an error message. 
+Where each entry corresponds to a placement instruction, where `"status": 1` indicates a success, `"status": 0` that a block of that type is already there. This zero status may also appear when something else went wrong, such as when an invalid block ID was given. In such cases there also be a `"message"` attribute with an error message.
 
 # Read biomes `GET /biomes`
 
@@ -785,6 +785,47 @@ To remove a cat with UUID `"475fb218-68f1-4464-8ac5-e559afd8e00d"` (obtained usi
 ]
 ```
 
+# Read players `GET /players`
+
+Endpoint for reading all [players](https://minecraft.fandom.com/wiki/Player) from the world.
+
+## URL parameters
+
+
+| key         | valid values    | required | defaults to | description                                                                                                     |
+|-------------|-----------------|----------|-------------|-----------------------------------------------------------------------------------------------------------------|
+| includeData | `true`, `false` | no       | `false`     | If `true`, include [player data](https://minecraft.fandom.com/wiki/Player.dat_format#NBT_structure) in response |
+
+## Request headers
+
+[Default](#Request-headers)
+
+## Request body
+
+N/A
+
+## Response headers
+
+[Default](#Response-headers)
+
+## Response body
+
+The response should follow this [schema](./schema.players.get.json).
+
+## Example
+
+Given a world with 1 player named "Dev" in it, request `GET /players?includeData=true`:
+
+```json
+[
+  {
+    "name": "Dev",
+	"uuid": "380df991-f603-344c-a090-369bad2a924a",
+    "data": "{AbsorptionAmount:0.0f,Air:300s,Attributes:[{Base:0.0d,Name:\"forge:step_height_addition\"},{Base:0.10000000149011612d,Name:\"minecraft:generic.movement_speed\"},{Base:0.08d,Name:\"forge:entity_gravity\"}],Brain:{memories:{}},CanUpdate:1b,DataVersion:3120,DeathTime:0s,Dimension:\"minecraft:overworld\",EnderItems:[],FallDistance:0.0f,FallFlying:0b,Fire:-20s,Health:20.0f,HurtByTimestamp:0,HurtTime:0s,Inventory:[{Count:1b,Slot:0b,id:\"minecraft:obsidian\"},{Count:1b,Slot:1b,id:\"minecraft:flint_and_steel\",tag:{Damage:0}}],Invulnerable:0b,Motion:[0.0d,0.0d,0.0d],OnGround:0b,PortalCooldown:0,Pos:[-3.483559135420974d,-58.74889429576954d,-16.579720966624766d],Rotation:[1.6493444f,24.599985f],Score:0,SelectedItemSlot:1,SleepTimer:0s,UUID:[I;940439953,-167562164,-1601161573,-1389718966],XpLevel:0,XpP:0.0f,XpSeed:-275312302,XpTotal:0,abilities:{flySpeed:0.05f,flying:1b,instabuild:1b,invulnerable:1b,mayBuild:1b,mayfly:1b,walkSpeed:0.1f},foodExhaustionLevel:0.0f,foodLevel:20,foodSaturationLevel:5.0f,foodTickTimer:0,playerGameType:1,recipeBook:{isBlastingFurnaceFilteringCraftable:0b,isBlastingFurnaceGuiOpen:0b,isFilteringCraftable:0b,isFurnaceFilteringCraftable:0b,isFurnaceGuiOpen:0b,isGuiOpen:0b,isSmokerFilteringCraftable:0b,isSmokerGuiOpen:0b,recipes:[\"minecraft:flint_and_steel\",\"minecraft:enchanting_table\"],toBeDisplayed:[\"minecraft:flint_and_steel\",\"minecraft:enchanting_table\"]},seenCredits:0b,warden_spawn_tracker:{cooldown_ticks:0,ticks_since_last_warning:8788,warning_level:0}}"
+  }
+]
+```
+
 # Get build area `GET /buildarea`
 
 This returns the current specified build area. The build area can be set inside Minecraft using the `setbuildarea` command. This is just a convenience command to specify the area, it has no implications to where blocks can be placed or read on the map.
@@ -851,7 +892,7 @@ Plain-text response with the Minecraft version number.
 
 ## Example
 
-`GET /version` returns: 
+`GET /version` returns:
 ```
 1.19.2
 ```
@@ -889,45 +930,4 @@ JSON object containing the following:
   "minecraftVersion": "1.19.2",
   "interfaceVersion": "1.1.0"
 }
-```
-
-# Read players `GET /players`
-
-Endpoint for reading all [players](https://minecraft.fandom.com/wiki/Player) from the world.
-
-## URL parameters
-
-
-| key         | valid values                                          | required | defaults to | description                                                                                                 |
-|-------------|-------------------------------------------------------|----------|-------------|-------------------------------------------------------------------------------------------------------------|
-| includeData | `true`, `false`                                       | no       | `false`     | If `true`, include [player data](https://minecraft.fandom.com/wiki/Player.dat_format#NBT_structure) in response |
-
-
-## Request headers
-
-[Default](#Request-headers)
-
-## Request body
-
-N/A
-
-## Response headers
-
-[Default](#Response-headers)
-
-## Response body
-
-The response should follow this [schema](./schema.players.get.json).
-
-## Example
-
-Given a world with 1 player named "Dev" in it, request `GET /players?includeData=true`:
-
-```json
-[
-  {
-    "name": "Dev",
-    "data": "{AbsorptionAmount:0.0f,Air:300s,Attributes:[{Base:0.0d,Name:\"forge:step_height_addition\"},{Base:0.10000000149011612d,Name:\"minecraft:generic.movement_speed\"},{Base:0.08d,Name:\"forge:entity_gravity\"}],Brain:{memories:{}},CanUpdate:1b,DataVersion:3120,DeathTime:0s,Dimension:\"minecraft:overworld\",EnderItems:[],FallDistance:0.0f,FallFlying:0b,Fire:-20s,Health:20.0f,HurtByTimestamp:0,HurtTime:0s,Inventory:[{Count:1b,Slot:0b,id:\"minecraft:obsidian\"},{Count:1b,Slot:1b,id:\"minecraft:flint_and_steel\",tag:{Damage:0}}],Invulnerable:0b,Motion:[0.0d,0.0d,0.0d],OnGround:0b,PortalCooldown:0,Pos:[-3.483559135420974d,-58.74889429576954d,-16.579720966624766d],Rotation:[1.6493444f,24.599985f],Score:0,SelectedItemSlot:1,SleepTimer:0s,UUID:[I;940439953,-167562164,-1601161573,-1389718966],XpLevel:0,XpP:0.0f,XpSeed:-275312302,XpTotal:0,abilities:{flySpeed:0.05f,flying:1b,instabuild:1b,invulnerable:1b,mayBuild:1b,mayfly:1b,walkSpeed:0.1f},foodExhaustionLevel:0.0f,foodLevel:20,foodSaturationLevel:5.0f,foodTickTimer:0,playerGameType:1,recipeBook:{isBlastingFurnaceFilteringCraftable:0b,isBlastingFurnaceGuiOpen:0b,isFilteringCraftable:0b,isFurnaceFilteringCraftable:0b,isFurnaceGuiOpen:0b,isGuiOpen:0b,isSmokerFilteringCraftable:0b,isSmokerGuiOpen:0b,recipes:[\"minecraft:flint_and_steel\",\"minecraft:enchanting_table\"],toBeDisplayed:[\"minecraft:flint_and_steel\",\"minecraft:enchanting_table\"]},seenCredits:0b,warden_spawn_tracker:{cooldown_ticks:0,ticks_since_last_warning:8788,warning_level:0}}"
-  }
-]
 ```

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -807,9 +807,11 @@ Endpoint for reading all [players](https://minecraft.fandom.com/wiki/Player) fro
 ## URL parameters
 
 
-| key         | valid values    | required | defaults to | description                                                                                                     |
-|-------------|-----------------|----------|-------------|-----------------------------------------------------------------------------------------------------------------|
-| includeData | `true`, `false` | no       | `false`     | If `true`, include [player data](https://minecraft.fandom.com/wiki/Player.dat_format#NBT_structure) in response |
+| key         | valid values                                          | required | defaults to | description                                                                                                                                                                                      |
+|-------------|-------------------------------------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| includeData | `true`, `false`                                       | no       | `false`     | If `true`, include [player data](https://minecraft.fandom.com/wiki/Player.dat_format#NBT_structure) in response                                                                                  |
+| selector    | target selector string                                | no       | `@a`        | [Target selector](https://minecraft.fandom.com/wiki/Target_selectors) string for players. This must be URL encoded.                                                                              |
+| dimension   | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       |             | Which dimension of the world get the list of players from. This is only relevant when using positional arguments as part of the target selector query. Otherwise this parameter will be ignored. |
 
 ## Request headers
 

--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -10,6 +10,7 @@ This mod adds a few new console commands to Minecraft
 - `/setbuildarea <fromX> <fromY> <fromZ> <toX> <toY> <toZ>`
   - Sets a build area which can be referred to using the [GET /buildarea](docs/Endpoints.md:788) endpoint
   - Example `/setbuildarea ~ ~ ~ ~100 ~40 ~100`
+  - Using the command without arguments unsets the build area.
 - `/sethttpport <number>`
   - Changes the port number the HTTP interface can be reached from. Only comes into effect when Minecraft world is reloaded.
 - `/gethttpport`

--- a/docs/schema.entities.get.json
+++ b/docs/schema.entities.get.json
@@ -11,7 +11,8 @@
             "properties": {
                 "uuid": {
                     "type": "string",
-                    "format": "uuid"
+                    "format": "uuid",
+                    "description": "UUID of player entity"
                 },
                 "data": {
                     "type": "string",

--- a/docs/schema.players.get.json
+++ b/docs/schema.players.get.json
@@ -10,7 +10,13 @@
       "additionalProperties": false,
       "properties": {
         "name": {
-          "type": "string"
+          "type": "string",
+          "description": "Player name"
+        },
+        "uuid": {
+          "type": "string",
+          "format": "uuid",
+          "description": "UUID of player entity"
         },
         "data": {
           "type": "string",
@@ -22,7 +28,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "uuid"
       ],
       "title": "Player Information Element"
     }

--- a/docs/schema.players.get.json
+++ b/docs/schema.players.get.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "type": "array",
+  "items": {
+    "$ref": "#/definitions/PlayerInformationElement"
+  },
+  "definitions": {
+    "PlayerInformationElement": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "data": {
+          "type": "string",
+          "title": "Player Data",
+          "description": "SNBT string (https://minecraft.fandom.com/wiki/NBT_format#SNBT_format) containing player data (https://minecraft.fandom.com/wiki/Player.dat_format#NBT_structure) information. This is only included if URL parameter `includeData=true` is present. Example data is truncated, real player data is often much bigger.",
+          "examples": [
+            "{AbsorptionAmount:0.0f,Air:300s,Attributes:[{Base:0.0d,Name:\"forge:step_height_addition\"},{Base:0.10000000149011612d,Name:\"minecraft:generic.movement_speed\"},{Base:0.08d,Name:\"forge:entity_gravity\"}],Brain:{memories:{}}..."
+          ]
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Player Information Element"
+    }
+  }
+}

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
@@ -49,6 +49,7 @@ public class GdmcHttpServer {
         httpServer.createContext("/biomes", new BiomesHandler(mcServer));
         httpServer.createContext("/structure", new StructureHandler(mcServer));
         httpServer.createContext("/entities", new EntitiesHandler(mcServer));
+        httpServer.createContext("/players", new PlayersHandler(mcServer));
         httpServer.createContext("/", new InterfaceInfoHandler(mcServer));
     }
 }

--- a/src/main/java/com/gdmc/httpinterfacemod/commands/SetBuildAreaCommand.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/commands/SetBuildAreaCommand.java
@@ -18,19 +18,25 @@ public final class SetBuildAreaCommand {
 
     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
         dispatcher.register(Commands.literal(COMMAND_NAME)
+            .executes(SetBuildAreaCommand :: unsetBuildArea)
             .then(
                 Commands.argument("from", BlockPosArgument.blockPos())
             .then(
                 Commands.argument("to", BlockPosArgument.blockPos())
-            .executes( context -> perform(
+            .executes( context -> setBuildArea(
                 context,
                 context.getArgument("from", Coordinates.class).getBlockPos(context.getSource()),
                 context.getArgument("to", Coordinates.class).getBlockPos(context.getSource())
-            ))))
-        );
+        )))));
     }
 
-    private static int perform(CommandContext<CommandSourceStack> commandSourceContext, BlockPos from, BlockPos to) {
+    private static int unsetBuildArea(CommandContext<CommandSourceStack> commandSourceStackCommandContext) {
+        BuildAreaHandler.unsetBuildArea();
+        commandSourceStackCommandContext.getSource().sendSuccess(Component.nullToEmpty("Build area unset"), true);
+        return 1;
+    }
+
+    private static int setBuildArea(CommandContext<CommandSourceStack> commandSourceContext, BlockPos from, BlockPos to) {
         int x1 = from.getX();
         int y1 = from.getY();
         int z1 = from.getZ();

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/BuildAreaHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/BuildAreaHandler.java
@@ -8,56 +8,16 @@ import net.minecraft.server.MinecraftServer;
 import java.io.IOException;
 
 public class BuildAreaHandler extends HandlerBase {
-    public static class BuildArea {
-        private final int xFrom;
-        private final int yFrom;
-        private final int zFrom;
-        private final int xTo;
-        private final int yTo;
-        private final int zTo;
 
-        public int getxFrom() { return xFrom; }
-        public int getyFrom() { return yFrom; }
-        public int getzFrom() { return zFrom; }
-        public int getxTo() { return xTo; }
-        public int getyTo() { return yTo; }
-        public int getzTo() { return zTo; }
-
-        public BuildArea(int xFrom, int yFrom, int zFrom, int xTo, int yTo, int zTo) {
-            this.xFrom = xFrom;
-            this.yFrom = yFrom;
-            this.zFrom = zFrom;
-            this.xTo = xTo;
-            this.yTo = yTo;
-            this.zTo = zTo;
-        }
-
-        @Override
-        public String toString() {
-            return "BuildArea{" +
-                    "areaX=" + xFrom +
-                    ", areaZ=" + zFrom +
-                    ", areaSizeX=" + xTo +
-                    ", areaSizeZ=" + zTo +
-                    '}';
-        }
-    }
-
-//    private static final Logger LOGGER = LogManager.getLogger();
     private static BuildArea buildArea;
-
-    public static void setBuildArea(int xFrom, int yFrom, int zFrom, int xTo, int yTo, int zTo) {
-        buildArea = new BuildArea(xFrom, yFrom, zFrom, xTo, yTo, zTo);
-    }
 
     public BuildAreaHandler(MinecraftServer mcServer) {
         super(mcServer);
-        buildArea = null;
+        unsetBuildArea();
     }
 
     @Override
     public void internalHandle(HttpExchange httpExchange) throws IOException {
-        // throw errors when appropriate
         String method = httpExchange.getRequestMethod().toLowerCase();
         if (!method.equals("get")) {
             throw new HttpException("Please use GET method to request the build area.", 405);
@@ -73,5 +33,31 @@ public class BuildAreaHandler extends HandlerBase {
         setDefaultResponseHeaders(responseHeaders);
 
         resolveRequest(httpExchange, responseString);
+    }
+
+    public static void setBuildArea(int xFrom, int yFrom, int zFrom, int xTo, int yTo, int zTo) {
+        buildArea = new BuildArea(xFrom, yFrom, zFrom, xTo, yTo, zTo);
+    }
+
+    public static void unsetBuildArea() {
+        buildArea = null;
+    }
+
+    public static class BuildArea {
+        private final int xFrom;
+        private final int yFrom;
+        private final int zFrom;
+        private final int xTo;
+        private final int yTo;
+        private final int zTo;
+
+        public BuildArea(int xFrom, int yFrom, int zFrom, int xTo, int yTo, int zTo) {
+            this.xFrom = xFrom;
+            this.yFrom = yFrom;
+            this.zFrom = zFrom;
+            this.xTo = xTo;
+            this.yTo = yTo;
+            this.zTo = zTo;
+        }
     }
 }

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/EntitiesHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/EntitiesHandler.java
@@ -8,8 +8,10 @@ import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
 import net.minecraft.ReportedException;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.commands.arguments.EntitySummonArgument;
 import net.minecraft.commands.arguments.coordinates.Vec3Argument;
+import net.minecraft.commands.arguments.selector.EntitySelector;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.TagParser;
@@ -19,7 +21,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 
 import java.io.IOException;
@@ -42,6 +43,10 @@ public class EntitiesHandler extends HandlerBase {
 	private int dy;
 	private int dz;
 
+	// GET: Search entities using a Target Selector (https://minecraft.fandom.com/wiki/Target_selectors).
+	// Defaults to "@e[x=x,y=y,z=z,dx=dx,dy=dy,dz=dz]" (find all entities within area).
+	private String entitySelectorString;
+
 	// GET: Whether to include entity data https://minecraft.fandom.com/wiki/Entity_format#Entity_Format
 	private boolean includeData;
 	private String dimension;
@@ -63,6 +68,8 @@ public class EntitiesHandler extends HandlerBase {
 			dx = Integer.parseInt(queryParams.getOrDefault("dx", "1"));
 			dy = Integer.parseInt(queryParams.getOrDefault("dy", "1"));
 			dz = Integer.parseInt(queryParams.getOrDefault("dz", "1"));
+
+			entitySelectorString = queryParams.getOrDefault("selector", null);
 
 			includeData = Boolean.parseBoolean(queryParams.getOrDefault("includeData", "false"));
 
@@ -151,27 +158,34 @@ public class EntitiesHandler extends HandlerBase {
 		int zMin = Math.min(z, zOffset);
 		int zMax = Math.max(z, zOffset);
 
-		ServerLevel level = getServerLevel(dimension);
+		StringReader entitySelectorStringReader = new StringReader(
+			entitySelectorString != null && !entitySelectorString.isBlank() ?
+				entitySelectorString :
+				"@e[x=%s,y=%s,z=%s,dx=%s,dy=%s,dz=%s]".formatted(xMin, yMin, zMin, xMax, yMax, zMax)
+		);
+		try {
+			EntitySelector entitySelector = EntityArgument.entities().parse(entitySelectorStringReader);
+			CommandSourceStack cmdSrc = createCommandSource("GDMC-EntitiesHandler", dimension).withPosition(new Vec3(x, y, z));
+			List<? extends Entity> entityList = entitySelector.findEntities(cmdSrc);
 
-		List<Entity> entityList = level.getEntities(null, new AABB(xMin, yMin, zMin, xMax, yMax, zMax));
-
-		// Create a JsonArray with JsonObject, each contain a key-value pair for
-		// the x, y, z position, the block ID, the block state (if requested and available)
-		// and the block entity data (if requested and available).
-		JsonArray returnList = new JsonArray();
-		for (Entity entity : entityList) {
-			String entityId = entity.getEncodeId();
-			if (entityId == null) {
-				continue;
+			JsonArray returnList = new JsonArray();
+			for (Entity entity : entityList) {
+				String entityId = entity.getEncodeId();
+				if (entityId == null) {
+					continue;
+				}
+				JsonObject json = new JsonObject();
+				json.addProperty("uuid", entity.getStringUUID());
+				if (includeData) {
+					json.addProperty("data", getEntityDataAsStr(entity));
+				}
+				returnList.add(json);
 			}
-			JsonObject json = new JsonObject();
-			json.addProperty("uuid", entity.getStringUUID());
-			if (includeData) {
-				json.addProperty("data", getEntityDataAsStr(entity));
-			}
-			returnList.add(json);
+			return returnList;
+		} catch (CommandSyntaxException e) {
+			throw new HttpException("Malformed entity target selector: " + e.getMessage(), 400);
 		}
-		return returnList;
+
 	}
 
 	/**

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/EntitiesHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/EntitiesHandler.java
@@ -177,7 +177,7 @@ public class EntitiesHandler extends HandlerBase {
 				JsonObject json = new JsonObject();
 				json.addProperty("uuid", entity.getStringUUID());
 				if (includeData) {
-					json.addProperty("data", getEntityDataAsStr(entity));
+					json.addProperty("data", entity.serializeNBT().getAsString());
 				}
 				returnList.add(json);
 			}
@@ -272,17 +272,6 @@ public class EntitiesHandler extends HandlerBase {
 		}
 
 		return returnValues;
-	}
-
-	private String getEntityDataAsStr(Entity entity) {
-		if (!includeData) {
-			return "";
-		}
-		CompoundTag tags = entity.serializeNBT();
-		if (tags != null) {
-			return tags.getAsString();
-		}
-		return "{}";
 	}
 
 	private final static class SummonEntityInstruction {

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
@@ -21,7 +21,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -135,14 +134,6 @@ public abstract class HandlerBase implements HttpHandler {
     }
 
     /**
-     * @param header single header as string from request or response headers
-     * @return {@code true} if header string has a common description of a JSON Content-Type.
-     */
-    protected static boolean hasJsonTypeInHeader(String header) {
-        return header.equals("application/json") || header.equals("text/json");
-    }
-
-    /**
      * Helper to add basic headers to headers of a response.
      *
      * @param headers request or response headers
@@ -211,15 +202,17 @@ public abstract class HandlerBase implements HttpHandler {
         int last = 0, next, l = qs.length();
         while (last < l) {
             next = qs.indexOf('&', last);
-            if (next == -1)
+            if (next == -1) {
                 next = l;
+            }
 
             if (next > last) {
                 int eqPos = qs.indexOf('=', last);
-                if (eqPos < 0 || eqPos > next)
+                if (eqPos < 0 || eqPos > next) {
                     result.put(URLDecoder.decode(qs.substring(last, next), StandardCharsets.UTF_8), "");
-                else
+                } else {
                     result.put(URLDecoder.decode(qs.substring(last, eqPos), StandardCharsets.UTF_8), URLDecoder.decode(qs.substring(eqPos + 1, next), StandardCharsets.UTF_8));
+                }
             }
             last = next + 1;
         }
@@ -255,9 +248,7 @@ public abstract class HandlerBase implements HttpHandler {
     protected CommandSourceStack createCommandSource(String name, String dimension, Vec3 pos) {
         CommandSource commandSource = new CommandSource() {
             @Override
-            public void sendSystemMessage(@NotNull Component p_230797_) {
-
-            }
+            public void sendSystemMessage(Component p_230797_) {}
 
             @Override
             public boolean acceptsSuccess() {

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/PlayersHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/PlayersHandler.java
@@ -43,11 +43,12 @@ public class PlayersHandler extends HandlerBase {
             // Get a collection of all the players on the server
             List<ServerPlayer> players = playerList.getPlayers();
 
-            // Add each player's name, position and dimension to the response list
+            // Add each player's name, UUID and additional data to the response list.
             for (ServerPlayer player : players) {
                 JsonObject json = new JsonObject();
-                // Name as unique identifier
+                // Name and UUID.
                 json.addProperty("name", player.getName().getString());
+                json.addProperty("uuid", player.getStringUUID());
                 // All player NBT data if requested
                 if (includeData) {
                     json.addProperty("data", player.serializeNBT().getAsString());

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/PlayersHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/PlayersHandler.java
@@ -1,0 +1,67 @@
+package com.gdmc.httpinterfacemod.handlers;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.players.PlayerList;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class PlayersHandler extends HandlerBase {
+    public PlayersHandler(MinecraftServer mcServer) { super(mcServer); }
+
+    private boolean includeData;
+
+    @Override
+    protected void internalHandle(HttpExchange httpExchange) throws IOException {
+
+        String method = httpExchange.getRequestMethod().toLowerCase();
+
+        JsonArray responseList = new JsonArray();
+
+        if (method.equals("get")) {
+
+            // Query parameters
+            Map<String, String> queryParams = parseQueryString(httpExchange.getRequestURI().getRawQuery());
+
+            // Check if they want all data included
+            try {
+                includeData = Boolean.parseBoolean(queryParams.getOrDefault("includeData", "false"));
+            } catch (NumberFormatException e) {
+                String message = "Could not parse query parameter: " + e.getMessage();
+                throw new HttpException(message, 400);
+            }
+
+            // Get the player list
+            PlayerList playerList = mcServer.getPlayerList();
+
+            // Get a collection of all the players on the server
+            List<ServerPlayer> players = playerList.getPlayers();
+
+            // Add each player's name, position and dimension to the response list
+            for (ServerPlayer player : players) {
+                JsonObject json = new JsonObject();
+                // Name as unique identifier
+                json.addProperty("name", player.getName().getString());
+                // All player NBT data if requested
+                if (includeData) {
+                    json.addProperty("data", player.serializeNBT().getAsString());
+                }
+                responseList.add(json);
+            }
+        } else {
+            throw new HttpException("Method not allowed. Only GET requests are supported.", 405);
+        }
+
+        // Response headers
+        Headers responseHeaders = httpExchange.getResponseHeaders();
+        setDefaultResponseHeaders(responseHeaders);
+
+        resolveRequest(httpExchange, responseList.toString());
+    }
+}


### PR DESCRIPTION
Changelog for v1.2.0:

- NEW: Add `GET /players` endpoint to get all players on the server. Thanks to [cmoyates](https://github.com/cmoyates)!
- NEW: Add support for [target selector](https://minecraft.fandom.com/wiki/Target_selectors) for entities in the `GET /entities` endpoint using the `selector` query parameter.
- NEW: Add support for [target selector](https://minecraft.fandom.com/wiki/Target_selectors) for players in the `GET /players` endpoint using the `selector` query parameter.
- NEW: Unset build area by entering the `/setbuildarea` command without arguments.