### PR TITLE
V1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# GDMC-HTTP 1.3.0 (Minecraft 1.19.2)
+
+- NEW: Add `GET /heightmap` to get heightmap data of a given [type](https://minecraft.fandom.com/wiki/Heightmap) of the currently set build area. Thanks to [cmoyates](https://github.com/cmoyates)!
+- NEW: Add custom heightmap types `MOTION_BLOCKING_NO_PLANTS` and `OCEAN_FLOOR_NO_PLANTS`.
+- NEW: Add `withinBuildArea` flag to `GET /BLOCKS`. If set to true it skips over positions outside of the build area.
+- NEW: Add `withinBuildArea` flag to `PUT /BLOCKS`. If set to true it does not place blocks outside of the build area.
+
 # GDMC-HTTP 1.2.3 (Minecraft 1.19.2)
 
 - FIX: With `PUT /blocks`, allow for changing the block entity (NBT) data of a block even if the target block matches the block state and block ID of the placement instruction. This makes it possible to do things such as changing the text on an existing sign or changing the items of an already placed chest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# GDMC-HTTP 1.3.0 (Minecraft 1.19.2)
+# GDMC-HTTP 1.3.2 (Minecraft 1.19.2)
 
 - NEW: Add `GET /heightmap` to get heightmap data of a given [type](https://minecraft.fandom.com/wiki/Heightmap) of the currently set build area. Thanks to [cmoyates](https://github.com/cmoyates)!
 - NEW: Add custom heightmap types `MOTION_BLOCKING_NO_PLANTS` and `OCEAN_FLOOR_NO_PLANTS`.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ GET,PUT,PATCH,DELETE    /entities   Read, create, edit and remove entities from 
 GET                     /buildarea  Get the build area defined by the /setbuildarea chat command
 GET                     /version    Get Minecraft version
 GET                     /players    Read players from the world
+GET                     /heightmap  Get heightmap of the set build area of a certain type
 ```
 
 A detailed documentation of the endpoints can be found [over here](./docs/Endpoints.md).

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'net.minecraftforge.gradle' version '5.1.+'
 }
 
-version = '1.3.0'
+version = '1.3.1'
 group = 'com.nilsgawlik.gdmchttp' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'gdmchttp'
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'net.minecraftforge.gradle' version '5.1.+'
 }
 
-version = '1.2.3'
+version = '1.3.0'
 group = 'com.nilsgawlik.gdmchttp' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'gdmchttp'
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'net.minecraftforge.gradle' version '5.1.+'
 }
 
-version = '1.3.1'
+version = '1.3.2'
 group = 'com.nilsgawlik.gdmchttp' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'gdmchttp'
 

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -130,17 +130,18 @@ Get information for one or more blocks in a given area.
 
 ## URL parameters
 
-| key          | valid values                                          | required | defaults to | description                                                                                                            |
-|--------------|-------------------------------------------------------|----------|-------------|------------------------------------------------------------------------------------------------------------------------|
-| x            | integer                                               | yes      | `0`         | X coordinate                                                                                                           |
-| y            | integer                                               | yes      | `0`         | Y coordinate                                                                                                           |
-| z            | integer                                               | yes      | `0`         | Z coordinate                                                                                                           |
-| dx           | integer                                               | no       | `1`         | Range of blocks to get counting from x (can be negative)                                                               |
-| dy           | integer                                               | no       | `1`         | Range of blocks to get counting from y (can be negative)                                                               |
-| dz           | integer                                               | no       | `1`         | Range of blocks to get counting from z (can be negative)                                                               |
-| includeState | `true`, `false`                                       | no       | `false`     | If `true`, include [block state](https://minecraft.fandom.com/wiki/Block_states) in response                           |
-| includeData  | `true`, `false`                                       | no       | `false`     | If `true`, include [block entity data](https://minecraft.fandom.com/wiki/Chunk_format#Block_entity_format) in response |
-| dimension    | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       | `overworld` | Which dimension of the world to read blocks from                                                                       |
+| key             | valid values                                          | required | defaults to | description                                                                                                            |
+|-----------------|-------------------------------------------------------|----------|-------------|------------------------------------------------------------------------------------------------------------------------|
+| x               | integer                                               | yes      | `0`         | X coordinate                                                                                                           |
+| y               | integer                                               | yes      | `0`         | Y coordinate                                                                                                           |
+| z               | integer                                               | yes      | `0`         | Z coordinate                                                                                                           |
+| dx              | integer                                               | no       | `1`         | Range of blocks to get counting from x (can be negative)                                                               |
+| dy              | integer                                               | no       | `1`         | Range of blocks to get counting from y (can be negative)                                                               |
+| dz              | integer                                               | no       | `1`         | Range of blocks to get counting from z (can be negative)                                                               |
+| includeState    | `true`, `false`                                       | no       | `false`     | If `true`, include [block state](https://minecraft.fandom.com/wiki/Block_states) in response                           |
+| includeData     | `true`, `false`                                       | no       | `false`     | If `true`, include [block entity data](https://minecraft.fandom.com/wiki/Chunk_format#Block_entity_format) in response |
+| withinBuildArea | `true`, `false`                                       | no       | `false`     | If `true`, skip over positions that are outside the build area                                                         |
+| dimension       | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       | `overworld` | Which dimension of the world to read blocks from                                                                       |
 
 ## Request headers
 
@@ -270,15 +271,16 @@ Place one or more blocks into the world.
 
 ## URL parameters
 
-| key            | valid values                                          | required | defaults to | description                                                                                                                                            |
-|----------------|-------------------------------------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| x              | integer                                               | yes      | `0`         | X coordinate                                                                                                                                           |
-| y              | integer                                               | yes      | `0`         | Y coordinate                                                                                                                                           |
-| z              | integer                                               | yes      | `0`         | Z coordinate                                                                                                                                           |
-| doBlockUpdates | `true`, `false`                                       | no       | `true`      | If `true`, tell neighbouring blocks to reach to placement, see [Controlling block update behavior](#controlling-block-update-behavior).                |
-| spawnDrops     | `true`, `false`                                       | no       | `false`     | If `true`, drop items if existing blocks are destroyed by this placement, see [Controlling block update behavior](#controlling-block-update-behavior). |
-| customFlags    | bit string                                            | no       | `0100011`   | Force certain behaviour when placing blocks, see [Controlling block update behavior](#controlling-block-update-behavior).                              |
-| dimension      | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       | `overworld` | Which dimension of the world to place blocks in                                                                                                        |
+| key             | valid values                                          | required | defaults to | description                                                                                                                                            |
+|-----------------|-------------------------------------------------------|----------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| x               | integer                                               | yes      | `0`         | X coordinate                                                                                                                                           |
+| y               | integer                                               | yes      | `0`         | Y coordinate                                                                                                                                           |
+| z               | integer                                               | yes      | `0`         | Z coordinate                                                                                                                                           |
+| doBlockUpdates  | `true`, `false`                                       | no       | `true`      | If `true`, tell neighbouring blocks to reach to placement, see [Controlling block update behavior](#controlling-block-update-behavior).                |
+| spawnDrops      | `true`, `false`                                       | no       | `false`     | If `true`, drop items if existing blocks are destroyed by this placement, see [Controlling block update behavior](#controlling-block-update-behavior). |
+| customFlags     | bit string                                            | no       | `0100011`   | Force certain behaviour when placing blocks, see [Controlling block update behavior](#controlling-block-update-behavior).                              |
+| withinBuildArea | `true`, `false`                                       | no       | `false`     | If `true`, do not place blocks at positions outside the build area.                                                                                    |
+| dimension       | `overworld`, `the_nether`, `the_end`, `nether`, `end` | no       | `overworld` | Which dimension of the world to place blocks in                                                                                                        |
 
 ### Controlling block update behavior
 

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -888,10 +888,28 @@ Returns the [heightmap](https://minecraft.fandom.com/wiki/Heightmap) of the set 
 
 ## URL parameters
 
-| key       | valid values                                                                   | required | defaults to     | description                                                                                                                                                                            |
-|-----------|--------------------------------------------------------------------------------|----------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| type      | `WORLD_SURFACE`, `OCEAN_FLOOR`, `MOTION_BLOCKING`, `MOTION_BLOCKING_NO_LEAVES` | no       | `WORLD_SURFACE` | Type of heightmap to get. See [Heightmap](https://minecraft.fandom.com/wiki/Heightmap) wiki page for more information.                                                                 |
-| dimension | `overworld`, `the_nether`, `the_end`, `nether`, `end`                          | no       | `overworld`     | Dimension of the world to get the heightmap for. Do note that heightmaps for The Nether will commonly return `128` for all positions due to there being no open sky in this dimension. |
+| key       | valid values                                                                                                                         | required | defaults to     | description                                                                                                                                                                            |
+|-----------|--------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| type      | `WORLD_SURFACE`, `OCEAN_FLOOR`, `MOTION_BLOCKING`, `MOTION_BLOCKING_NO_LEAVES`, `MOTION_BLOCKING_NO_PLANTS`, `OCEAN_FLOOR_NO_PLANTS` | no       | `WORLD_SURFACE` | Type of heightmap to get. See [Heightmap](https://minecraft.fandom.com/wiki/Heightmap) wiki page for more information.                                                                 |
+| dimension | `overworld`, `the_nether`, `the_end`, `nether`, `end`                                                                                | no       | `overworld`     | Dimension of the world to get the heightmap for. Do note that heightmaps for The Nether will commonly return `128` for all positions due to there being no open sky in this dimension. |
+
+In addition to the build-in height map types of `WORLD_SURFACE`, `OCEAN_FLOOR`, `MOTION_BLOCKING` and `MOTION_BLOCKING_NO_LEAVES`, this mod also includes the following custom height maps:
+- `MOTION_BLOCKING_NO_PLANTS`
+  - Same as `MOTION_BLOCKING_NO_LEAVES`, except it also excludes the following blocks
+    - All logs
+    - Bee nests
+    - Mangrove roots
+    - Giant mushroom blocks
+    - All types of pumpkin blocks
+    - Melon blocks
+    - Cactus blocks
+    - Farmland
+    - Coral blocks
+    - Sponges
+- `OCEAN_FLOOR_NO_PLANTS`
+  - Same as `OCEAN_FLOOR`, except it also excludes the following blocks:
+    - Leaves
+    - Everything listed for `MOTION_BLOCKING_NO_PLANTS`
 
 ## Request headers
 

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -897,20 +897,25 @@ Returns the [heightmap](https://minecraft.fandom.com/wiki/Heightmap) of the set 
 
 In addition to the build-in height map types of `WORLD_SURFACE`, `OCEAN_FLOOR`, `MOTION_BLOCKING` and `MOTION_BLOCKING_NO_LEAVES`, this mod also includes the following custom height maps:
 - `MOTION_BLOCKING_NO_PLANTS`
-  - Same as `MOTION_BLOCKING_NO_LEAVES`, except it also excludes the following blocks
-    - All logs
+  - Same as `MOTION_BLOCKING`, except it also excludes the following blocks
+    - Logs
+    - Leaves
     - Bee nests
     - Mangrove roots
     - Giant mushroom blocks
-    - All types of pumpkin blocks
+    - Pumpkin blocks
     - Melon blocks
+    - Moss blocks
+    - Nether wart blocks
     - Cactus blocks
     - Farmland
     - Coral blocks
     - Sponges
+    - Bamboo plants
+    - Cobwebs
+    - Sculk
 - `OCEAN_FLOOR_NO_PLANTS`
   - Same as `OCEAN_FLOOR`, except it also excludes the following blocks:
-    - Leaves
     - Everything listed for `MOTION_BLOCKING_NO_PLANTS`
 
 ## Request headers

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -882,6 +882,63 @@ After having set the build area in game with `/setbuildarea ~ ~ ~ ~200 ~200 ~200
 { "xFrom": 2353, "yFrom": 63, "zFrom": -78, "xTo": 2553, "yTo": 263, "zTo": 122 }
 ```
 
+# Get heightmap `GET /heightmap`
+
+Returns the [heightmap](https://minecraft.fandom.com/wiki/Heightmap) of the set build area of a given type.
+
+## URL parameters
+
+| key       | valid values                                                                   | required | defaults to     | description                                                                                                                                                                            |
+|-----------|--------------------------------------------------------------------------------|----------|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| type      | `WORLD_SURFACE`, `OCEAN_FLOOR`, `MOTION_BLOCKING`, `MOTION_BLOCKING_NO_LEAVES` | no       | `WORLD_SURFACE` | Type of heightmap to get. See [Heightmap](https://minecraft.fandom.com/wiki/Heightmap) wiki page for more information.                                                                 |
+| dimension | `overworld`, `the_nether`, `the_end`, `nether`, `end`                          | no       | `overworld`     | Dimension of the world to get the heightmap for. Do note that heightmaps for The Nether will commonly return `128` for all positions due to there being no open sky in this dimension. |
+
+## Request headers
+
+[Default](#Request-headers)
+
+## Request body
+
+N/A
+
+## Response headers
+
+[Default](#Response-headers)
+
+## Response body
+
+A 2D array with integer values representing the heightmap of the x-z dimensions of the build area.
+
+## Example
+
+After having set the build area in game with `/setbuildarea ~ ~ ~ ~20 ~20 ~20`, requesting the heightmap of that ignores water with `GET /heightmap?type=OCEAN_FLOOR` could return:
+
+```json
+[
+  [68,68,66,65,65,65,72,72,72,74,74,74,71,65,65,65,65,65,68,71,71],
+  [67,68,66,65,65,72,72,73,72,72,74,71,71,64,64,64,64,64,68,68,71],
+  [66,67,67,65,65,72,73,74,73,72,71,71,63,63,63,63,63,63,63,68,68],
+  [66,66,66,66,65,72,72,73,72,72,63,63,63,63,63,63,63,63,63,63,63],
+  [65,66,65,65,65,64,72,72,72,63,63,63,63,63,63,63,63,63,63,63,63],
+  [64,64,64,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [63,64,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [64,64,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [65,65,65,64,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [66,66,66,65,65,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [66,67,66,66,65,65,63,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [66,67,66,66,66,65,65,63,63,63,63,63,63,63,63,63,63,63,63,63,63],
+  [66,67,67,66,66,65,65,64,64,63,63,64,64,64,64,64,65,65,65,64,64],
+  [66,67,67,66,72,72,72,65,64,64,64,64,65,65,65,65,66,66,66,66,66],
+  [66,67,67,72,72,75,72,72,65,65,65,65,65,66,66,66,67,67,67,67,67]
+]
+```
+
 # Read Minecraft version `GET /version`
 
 Get the current version of Minecraft.

--- a/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/GdmcHttpServer.java
@@ -50,6 +50,7 @@ public class GdmcHttpServer {
         httpServer.createContext("/structure", new StructureHandler(mcServer));
         httpServer.createContext("/entities", new EntitiesHandler(mcServer));
         httpServer.createContext("/players", new PlayersHandler(mcServer));
+        httpServer.createContext("/heightmap", new HeightmapHandler(mcServer));
         httpServer.createContext("/", new InterfaceInfoHandler(mcServer));
     }
 }

--- a/src/main/java/com/gdmc/httpinterfacemod/commands/SetBuildAreaCommand.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/commands/SetBuildAreaCommand.java
@@ -37,15 +37,8 @@ public final class SetBuildAreaCommand {
     }
 
     private static int setBuildArea(CommandContext<CommandSourceStack> commandSourceContext, BlockPos from, BlockPos to) {
-        int x1 = from.getX();
-        int y1 = from.getY();
-        int z1 = from.getZ();
-        int x2 = to.getX();
-        int y2 = to.getY();
-        int z2 = to.getZ();
-
-        BuildAreaHandler.setBuildArea(x1, y1, z1, x2, y2, z2);
-        String feedback = String.format("Build area set to %d, %d, %d to %d, %d, %d,", x1, y1, z1, x2, y2, z2 );
+        BuildAreaHandler.setBuildArea(from, to);
+        String feedback = String.format("Build area set to %s to %s", from.toShortString(), to.toShortString());
         commandSourceContext.getSource().sendSuccess(Component.nullToEmpty(feedback), true);
         return 1;
     }

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/BlocksHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/BlocksHandler.java
@@ -1,5 +1,6 @@
 package com.gdmc.httpinterfacemod.handlers;
 
+import com.gdmc.httpinterfacemod.handlers.BuildAreaHandler.BuildArea;
 import com.gdmc.httpinterfacemod.utils.TagComparator;
 import com.google.gson.*;
 import com.mojang.brigadier.StringReader;
@@ -67,6 +68,9 @@ public class BlocksHandler extends HandlerBase {
     // https://minecraft.fandom.com/wiki/Block_update
     private int customFlags; // -1 == no custom flags
 
+    // PUT/GET is true, constrain placement/getting blocks within the current build area.
+    private boolean withinBuildArea;
+
     private String dimension;
 
     public BlocksHandler(MinecraftServer mcServer) {
@@ -99,6 +103,8 @@ public class BlocksHandler extends HandlerBase {
             spawnDrops = Boolean.parseBoolean(queryParams.getOrDefault("spawnDrops", "false"));
 
             customFlags = Integer.parseInt(queryParams.getOrDefault("customFlags", "-1"), 2);
+
+            withinBuildArea = Boolean.parseBoolean(queryParams.getOrDefault("withinBuildArea", "false"));
 
             dimension = queryParams.getOrDefault("dimension", null);
         } catch (NumberFormatException e) {
@@ -145,6 +151,14 @@ public class BlocksHandler extends HandlerBase {
             throw new HttpException("Malformed JSON: " + jsonSyntaxException.getMessage(), 400);
         }
 
+        BuildArea buildArea = null;
+        if (withinBuildArea) {
+            buildArea = BuildAreaHandler.getBuildArea();
+            if (buildArea == null) {
+                throw new HttpException("No build area is specified. Use the setbuildarea command inside Minecraft to set a build area.", 404);
+            }
+        }
+
         for (JsonElement blockPlacement : blockPlacementList) {
             JsonObject blockPlacementItem = blockPlacement.getAsJsonObject();
             try {
@@ -159,6 +173,11 @@ public class BlocksHandler extends HandlerBase {
                     "%s %s %s".formatted(posXString, posYString, posZString),
                     commandSourceStack
                 );
+
+                if (withinBuildArea && buildArea != null && buildArea.isOutsideBuildArea(blockPos)) {
+                    returnValues.add(instructionStatus(false, "position is outside build area " + blockPlacement));
+                    continue;
+                }
 
                 // Skip if block id is missing
                 if (!blockPlacementItem.has("id")) {
@@ -225,6 +244,14 @@ public class BlocksHandler extends HandlerBase {
         int zMin = Math.min(z, zOffset);
         int zMax = Math.max(z, zOffset);
 
+        BuildArea buildArea = null;
+        if (withinBuildArea) {
+            buildArea = BuildAreaHandler.getBuildArea();
+            if (buildArea == null) {
+                throw new HttpException("No build area is specified. Use the setbuildarea command inside Minecraft to set a build area.", 404);
+            }
+        }
+
         // Create a JsonArray with JsonObject, each contain a key-value pair for
         // the x, y, z position, the block ID, the block state (if requested and available)
         // and the block entity data (if requested and available).
@@ -233,6 +260,9 @@ public class BlocksHandler extends HandlerBase {
             for (int rangeY = yMin; rangeY < yMax; rangeY++) {
                 for (int rangeZ = zMin; rangeZ < zMax; rangeZ++) {
                     BlockPos blockPos = new BlockPos(rangeX, rangeY, rangeZ);
+                    if (withinBuildArea                                                     && buildArea != null && buildArea.isOutsideBuildArea(blockPos)) {
+                        continue;
+                    }
                     String blockId = getBlockAsStr(blockPos);
                     JsonObject json = new JsonObject();
                     json.addProperty("id", blockId);

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/BlocksHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/BlocksHandler.java
@@ -260,7 +260,7 @@ public class BlocksHandler extends HandlerBase {
             for (int rangeY = yMin; rangeY < yMax; rangeY++) {
                 for (int rangeZ = zMin; rangeZ < zMax; rangeZ++) {
                     BlockPos blockPos = new BlockPos(rangeX, rangeY, rangeZ);
-                    if (withinBuildArea                                                     && buildArea != null && buildArea.isOutsideBuildArea(blockPos)) {
+                    if (withinBuildArea && buildArea != null && buildArea.isOutsideBuildArea(blockPos)) {
                         continue;
                     }
                     String blockId = getBlockAsStr(blockPos);

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/BuildAreaHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/BuildAreaHandler.java
@@ -69,5 +69,13 @@ public class BuildAreaHandler extends HandlerBase {
             this.from = _from;
             this.to = _to;
         }
+
+        public boolean isOutsideBuildArea(BlockPos pos) {
+            return isOutsideBuildArea(pos.getX(), pos.getZ());
+        }
+
+        public boolean isOutsideBuildArea(int x, int z) {
+            return x < from.getX() || x > to.getX() || z < from.getZ() || z > to.getZ();
+        }
     }
 }

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/BuildAreaHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/BuildAreaHandler.java
@@ -3,6 +3,7 @@ package com.gdmc.httpinterfacemod.handlers;
 import com.google.gson.Gson;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpExchange;
+import net.minecraft.core.BlockPos;
 import net.minecraft.server.MinecraftServer;
 
 import java.io.IOException;
@@ -10,6 +11,10 @@ import java.io.IOException;
 public class BuildAreaHandler extends HandlerBase {
 
     private static BuildArea buildArea;
+
+    public static BuildArea getBuildArea() {
+        return buildArea;
+    }
 
     public BuildAreaHandler(MinecraftServer mcServer) {
         super(mcServer);
@@ -27,23 +32,23 @@ public class BuildAreaHandler extends HandlerBase {
             throw new HttpException("No build area is specified. Use the buildarea command inside Minecraft to set a build area.", 404);
         }
 
-        String responseString = new Gson().toJson(buildArea);
-
         Headers responseHeaders = httpExchange.getResponseHeaders();
         setDefaultResponseHeaders(responseHeaders);
 
-        resolveRequest(httpExchange, responseString);
+        resolveRequest(httpExchange, new Gson().toJson(buildArea));
     }
 
-    public static void setBuildArea(int xFrom, int yFrom, int zFrom, int xTo, int yTo, int zTo) {
-        buildArea = new BuildArea(xFrom, yFrom, zFrom, xTo, yTo, zTo);
+    public static void setBuildArea(BlockPos from, BlockPos to) {
+        buildArea = new BuildArea(from, to);
     }
 
     public static void unsetBuildArea() {
         buildArea = null;
     }
 
+    @SuppressWarnings({"FieldCanBeLocal", "unused"})
     public static class BuildArea {
+
         private final int xFrom;
         private final int yFrom;
         private final int zFrom;
@@ -51,13 +56,18 @@ public class BuildAreaHandler extends HandlerBase {
         private final int yTo;
         private final int zTo;
 
-        public BuildArea(int xFrom, int yFrom, int zFrom, int xTo, int yTo, int zTo) {
-            this.xFrom = xFrom;
-            this.yFrom = yFrom;
-            this.zFrom = zFrom;
-            this.xTo = xTo;
-            this.yTo = yTo;
-            this.zTo = zTo;
+        public final transient BlockPos from;
+        public final transient BlockPos to;
+
+        public BuildArea(BlockPos _from, BlockPos _to) {
+            this.xFrom = _from.getX();
+            this.yFrom = _from.getY();
+            this.zFrom = _from.getZ();
+            this.xTo = _to.getX();
+            this.yTo = _to.getY();
+            this.zTo = _to.getZ();
+            this.from = _from;
+            this.to = _to;
         }
     }
 }

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
@@ -43,7 +43,7 @@ public abstract class HandlerBase implements HttpHandler {
 
     protected static final Logger LOGGER = LogManager.getLogger();
 
-    final MinecraftServer mcServer;
+    public final MinecraftServer mcServer;
     public HandlerBase(MinecraftServer mcServer) {
         this.mcServer = mcServer;
     }

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/HandlerBase.java
@@ -127,10 +127,10 @@ public abstract class HandlerBase implements HttpHandler {
 
     protected static String getHeader(Headers headers, String key, String defaultValue) {
         List<String> list = headers.get(key);
-        if(list == null || list.size() == 0)
+        if(list == null || list.size() == 0) {
             return defaultValue;
-        else
-            return list.get(0);
+        }
+        return list.get(0);
     }
 
     /**

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/HeightmapHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/HeightmapHandler.java
@@ -1,0 +1,113 @@
+package com.gdmc.httpinterfacemod.handlers;
+
+import com.gdmc.httpinterfacemod.handlers.BuildAreaHandler.BuildArea;
+import com.google.gson.Gson;
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.Heightmap.Types;
+
+import java.io.IOException;
+import java.util.Map;
+
+// https://github.com/Niels-NTG/gdmc_http_interface/pull/19
+
+public class HeightmapHandler extends HandlerBase {
+
+    public HeightmapHandler(MinecraftServer mcServer) {
+        super(mcServer);
+    }
+
+    @Override
+    protected void internalHandle(HttpExchange httpExchange) throws IOException {
+
+        String method = httpExchange.getRequestMethod().toLowerCase();
+
+        if (!method.equals("get")) {
+            throw new HttpException("Method not allowed. Only GET requests are supported.", 405);
+        }
+
+        // Get query parameters
+        Map<String, String> queryParams = parseQueryString(httpExchange.getRequestURI().getRawQuery());
+        // Try to parse a type argument from them
+        String heightmapTypeString = queryParams.getOrDefault("type", "WORLD_SURFACE");
+        Types heightmapType;
+        // Check if the type is a valid heightmap type
+        try {
+            // If so, store the type object
+            heightmapType = Types.valueOf(heightmapTypeString);
+        } catch (IllegalArgumentException e) {
+            // Otherwise, throw an error
+            throw new HttpException("heightmap type " + heightmapTypeString + " is not supported.", 400);
+        }
+
+        String dimension = queryParams.getOrDefault("dimension", null);
+
+        // Get the build area
+        BuildArea buildArea = BuildAreaHandler.getBuildArea();
+        if (buildArea == null) {
+            throw new HttpException("No build area is specified. Use the setbuildarea command inside Minecraft to set a build area.", 404);
+        }
+
+        // Get a reference to the map/level
+        ServerLevel serverlevel = getServerLevel(dimension);
+
+        // Get the heightmap of that type
+        int[][] heightmap = getHeightmap(buildArea, serverlevel, heightmapType);
+
+        // Respond with that array as a string
+        Headers responseHeaders = httpExchange.getResponseHeaders();
+        setDefaultResponseHeaders(responseHeaders);
+        resolveRequest(httpExchange, new Gson().toJson(heightmap));
+    }
+
+
+    private static int[][] getHeightmap(BuildArea buildArea, ServerLevel serverlevel, Types heightmapType) {
+
+        // Get the x/z size of the build area
+        int xSize = buildArea.to.getX() - buildArea.from.getX() + 1;
+        int zSize = buildArea.to.getZ() - buildArea.from.getZ() + 1;
+        // Create the 2D array to store the heightmap data
+        int[][] heightmap = new int[xSize][zSize];
+
+        // Get the number of chunks
+        int xChunkCount = Math.floorDiv(buildArea.to.getX(), 16) - Math.floorDiv(buildArea.from.getX(), 16) + 1;
+        int zChunkCount = Math.floorDiv(buildArea.to.getZ(), 16) - Math.floorDiv(buildArea.from.getZ(), 16) + 1;
+
+        // Get the chunk x and z of the chunk at the lowest x and z
+        int minChunkX = Math.floorDiv(buildArea.from.getX(), 16);
+        int minChunkZ = Math.floorDiv(buildArea.from.getZ(), 16);
+
+        // For every chunk in the build area
+        for (int chunkX = minChunkX; chunkX < xChunkCount + minChunkX; ++chunkX) {
+            for (int chunkZ = minChunkZ; chunkZ < zChunkCount + minChunkZ; ++chunkZ) {
+
+                // Get the chunk
+                LevelChunk chunk = serverlevel.getChunk(chunkX, chunkZ);
+
+                // Get the heightmap of type
+                Heightmap chunkHeightmap = chunk.getOrCreateHeightmapUnprimed(heightmapType);
+
+                // For every combination of x and z in that chunk
+                int chunkMinX = chunkX * 16;
+                int chunkMinZ = chunkZ * 16;
+                for (int x = chunkMinX; x < chunkMinX + 16; ++x) {
+                    for (int z = chunkMinZ; z < chunkMinZ + 16; ++z) {
+                        // If the column is out of bounds skip it
+                        if (x < buildArea.from.getX() || x > buildArea.to.getX() || z < buildArea.from.getZ() || z > buildArea.to.getZ()) {
+                            continue;
+                        }
+                        // Set the value in the heightmap array
+                        heightmap[x - buildArea.from.getX()][z - buildArea.from.getZ()] = chunkHeightmap.getFirstAvailable(x - chunkMinX, z - chunkMinZ);
+                    }
+                }
+            }
+        }
+
+        // Return the completed heightmap array
+        return heightmap;
+    }
+}

--- a/src/main/java/com/gdmc/httpinterfacemod/handlers/HeightmapHandler.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/handlers/HeightmapHandler.java
@@ -146,7 +146,7 @@ public class HeightmapHandler extends HandlerBase {
                 for (int x = chunkMinX; x < chunkMinX + 16; ++x) {
                     for (int z = chunkMinZ; z < chunkMinZ + 16; ++z) {
                         // If the column is out of bounds skip it
-                        if (x < buildArea.from.getX() || x > buildArea.to.getX() || z < buildArea.from.getZ() || z > buildArea.to.getZ()) {
+                        if (buildArea.isOutsideBuildArea(x, z)) {
                             continue;
                         }
                         // Set the value in the heightmap array

--- a/src/main/java/com/gdmc/httpinterfacemod/utils/CustomHeightmap.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/utils/CustomHeightmap.java
@@ -1,6 +1,5 @@
 package com.gdmc.httpinterfacemod.utils;
 
-import com.mojang.serialization.Codec;
 import net.minecraft.core.BlockPos;
 import net.minecraft.tags.BlockTags;
 import net.minecraft.util.BitStorage;
@@ -10,7 +9,6 @@ import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Predicate;
 
@@ -77,18 +75,17 @@ public class CustomHeightmap {
 		;
 
 	public enum Types implements StringRepresentable {
-		MOTION_BLOCKING_NO_PLANTS(
+		@SuppressWarnings("unused") MOTION_BLOCKING_NO_PLANTS(
 			"MOTION_BLOCKING_NO_PLANTS",
 			(blockState) ->
 				(blockState.getMaterial().blocksMotion() || !blockState.getFluidState().isEmpty()) && NO_PLANTS.test(blockState)
 		),
-		OCEAN_FLOOR_NO_PLANTS(
+		@SuppressWarnings("unused") OCEAN_FLOOR_NO_PLANTS(
 			"OCEAN_FLOOR_NO_PLANTS",
 			(blockState) ->
 				blockState.getMaterial().blocksMotion() && NO_PLANTS.test(blockState)
 		);
 
-		public static final Codec<Types> CODEC = StringRepresentable.fromEnum(CustomHeightmap.Types::values);
 		private final String serializationKey;
 		private final Predicate<BlockState> isOpaque;
 		Types(String serializationKey, Predicate<BlockState> predicate) {
@@ -100,8 +97,9 @@ public class CustomHeightmap {
 			return this.isOpaque;
 		}
 
+		@SuppressWarnings("NullableProblems")
 		@Override
-		public @NotNull String getSerializedName() {
+		public String getSerializedName() {
 			return this.serializationKey;
 		}
 	}

--- a/src/main/java/com/gdmc/httpinterfacemod/utils/CustomHeightmap.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/utils/CustomHeightmap.java
@@ -64,14 +64,17 @@ public class CustomHeightmap {
 	}
 
 	private static final Predicate<BlockState> NO_PLANTS = blockState ->
-		!blockState.is(BlockTags.LEAVES) && !blockState.is(BlockTags.LOGS) && !blockState.is(Blocks.BEE_NEST) && !blockState.is(Blocks.MANGROVE_ROOTS) &&
+		!blockState.is(BlockTags.LEAVES) && !blockState.is(BlockTags.LOGS) && !blockState.is(Blocks.BEE_NEST) && !blockState.is(Blocks.MANGROVE_ROOTS) && !blockState.is(Blocks.MUDDY_MANGROVE_ROOTS) &&
 		!blockState.is(Blocks.BROWN_MUSHROOM_BLOCK) && !blockState.is(Blocks.RED_MUSHROOM_BLOCK) && !blockState.is(Blocks.MUSHROOM_STEM) &&
-		!blockState.is(Blocks.PUMPKIN) && !blockState.is(Blocks.CARVED_PUMPKIN) && !blockState.is(Blocks.JACK_O_LANTERN) &&
+		!blockState.is(Blocks.PUMPKIN) &&
 		!blockState.is(Blocks.MELON) &&
-		!blockState.is(Blocks.MOSS_BLOCK) &&
+		!blockState.is(Blocks.MOSS_BLOCK) && !blockState.is(Blocks.NETHER_WART_BLOCK) &&
 		!blockState.is(Blocks.CACTUS) &&
 		!blockState.is(Blocks.FARMLAND) &&
-		!blockState.is(BlockTags.CORAL_BLOCKS) && !blockState.is(Blocks.SPONGE) && !blockState.is(Blocks.WET_SPONGE)
+		!blockState.is(BlockTags.CORAL_BLOCKS) && !blockState.is(Blocks.SPONGE) && !blockState.is(Blocks.WET_SPONGE) &&
+		!blockState.is(Blocks.BAMBOO) &&
+		!blockState.is(Blocks.COBWEB) &&
+		!blockState.is(Blocks.SCULK)
 		;
 
 	public enum Types implements StringRepresentable {

--- a/src/main/java/com/gdmc/httpinterfacemod/utils/CustomHeightmap.java
+++ b/src/main/java/com/gdmc/httpinterfacemod/utils/CustomHeightmap.java
@@ -1,0 +1,108 @@
+package com.gdmc.httpinterfacemod.utils;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.util.BitStorage;
+import net.minecraft.util.Mth;
+import net.minecraft.util.SimpleBitStorage;
+import net.minecraft.util.StringRepresentable;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Predicate;
+
+public class CustomHeightmap {
+
+	private final BitStorage data;
+	private final Predicate<BlockState> isOpaque;
+	private final ChunkAccess chunk;
+
+	public CustomHeightmap(ChunkAccess chunk, Types heightmapType) {
+		this.isOpaque = heightmapType.isOpaque();
+		this.chunk = chunk;
+		int i = Mth.ceillog2(chunk.getHeight() + 1);
+		this.data = new SimpleBitStorage(i, 256);
+	}
+
+	public static CustomHeightmap primeHeightmaps(ChunkAccess chunk, CustomHeightmap.Types heightmapType) {
+		CustomHeightmap customHeightmap = new CustomHeightmap(chunk, heightmapType);
+		int j = chunk.getHighestSectionPosition() + 16;
+		BlockPos.MutableBlockPos blockpos$mutableblockpos = new BlockPos.MutableBlockPos();
+
+		for(int k = 0; k < 16; ++k) {
+			for(int l = 0; l < 16; ++l) {
+				for(int i1 = j - 1; i1 >= chunk.getMinBuildHeight(); --i1) {
+					blockpos$mutableblockpos.set(k, i1, l);
+					BlockState blockstate = chunk.getBlockState(blockpos$mutableblockpos);
+					if (!blockstate.is(Blocks.AIR)) {
+						if (customHeightmap.isOpaque.test(blockstate)) {
+							customHeightmap.setHeight(k, l, i1 + 1);
+							break;
+						}
+					}
+				}
+			}
+		}
+		return customHeightmap;
+	}
+
+	private void setHeight(int p_64246_, int p_64247_, int p_64248_) {
+		this.data.set(getIndex(p_64246_, p_64247_), p_64248_ - this.chunk.getMinBuildHeight());
+	}
+
+	public int getFirstAvailable(int p_64243_, int p_64244_) {
+		return this.getFirstAvailable(getIndex(p_64243_, p_64244_));
+	}
+
+	private int getFirstAvailable(int p_64241_) {
+		return this.data.get(p_64241_) + this.chunk.getMinBuildHeight();
+	}
+
+	private static int getIndex(int p_64266_, int p_64267_) {
+		return p_64266_ + p_64267_ * 16;
+	}
+
+	private static final Predicate<BlockState> NO_PLANTS = blockState ->
+		!blockState.is(BlockTags.LEAVES) && !blockState.is(BlockTags.LOGS) && !blockState.is(Blocks.BEE_NEST) && !blockState.is(Blocks.MANGROVE_ROOTS) &&
+		!blockState.is(Blocks.BROWN_MUSHROOM_BLOCK) && !blockState.is(Blocks.RED_MUSHROOM_BLOCK) && !blockState.is(Blocks.MUSHROOM_STEM) &&
+		!blockState.is(Blocks.PUMPKIN) && !blockState.is(Blocks.CARVED_PUMPKIN) && !blockState.is(Blocks.JACK_O_LANTERN) &&
+		!blockState.is(Blocks.MELON) &&
+		!blockState.is(Blocks.MOSS_BLOCK) &&
+		!blockState.is(Blocks.CACTUS) &&
+		!blockState.is(Blocks.FARMLAND) &&
+		!blockState.is(BlockTags.CORAL_BLOCKS) && !blockState.is(Blocks.SPONGE) && !blockState.is(Blocks.WET_SPONGE)
+		;
+
+	public enum Types implements StringRepresentable {
+		MOTION_BLOCKING_NO_PLANTS(
+			"MOTION_BLOCKING_NO_PLANTS",
+			(blockState) ->
+				(blockState.getMaterial().blocksMotion() || !blockState.getFluidState().isEmpty()) && NO_PLANTS.test(blockState)
+		),
+		OCEAN_FLOOR_NO_PLANTS(
+			"OCEAN_FLOOR_NO_PLANTS",
+			(blockState) ->
+				blockState.getMaterial().blocksMotion() && NO_PLANTS.test(blockState)
+		);
+
+		public static final Codec<Types> CODEC = StringRepresentable.fromEnum(CustomHeightmap.Types::values);
+		private final String serializationKey;
+		private final Predicate<BlockState> isOpaque;
+		Types(String serializationKey, Predicate<BlockState> predicate) {
+			this.serializationKey = serializationKey;
+			this.isOpaque = predicate;
+		}
+
+		public Predicate<BlockState> isOpaque() {
+			return this.isOpaque;
+		}
+
+		@Override
+		public @NotNull String getSerializedName() {
+			return this.serializationKey;
+		}
+	}
+}


### PR DESCRIPTION
- NEW: Add `GET /heightmap` to get heightmap data of a given [type](https://minecraft.fandom.com/wiki/Heightmap) of the currently set build area. Thanks to [cmoyates](https://github.com/cmoyates)!
- NEW: Add custom heightmap types `MOTION_BLOCKING_NO_PLANTS` and `OCEAN_FLOOR_NO_PLANTS`.
- NEW: Add `withinBuildArea` flag to `GET /BLOCKS`. If set to true it skips over positions outside of the build area.
- NEW: Add `withinBuildArea` flag to `PUT /BLOCKS`. If set to true it does not place blocks outside of the build area.