### PR TITLE
Add preflight handlers to route handlers

### DIFF
--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BiomesHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BiomesHandler.java
@@ -28,7 +28,9 @@ public class BiomesHandler extends HandlerBase {
 
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
-		if (resolvePreflight(httpExchange, "GET, PUT, OPTIONS", "Content-Type")) return;
+		if (resolvePreflight(httpExchange, "GET, PUT")) {
+			return;
+		}
 
 		if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
 			throw new HttpException("Method not allowed. Only GET requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BiomesHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BiomesHandler.java
@@ -28,6 +28,7 @@ public class BiomesHandler extends HandlerBase {
 
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
+		if (resolvePreflight(httpExchange, "GET, PUT, OPTIONS", "Content-Type")) return;
 
 		if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
 			throw new HttpException("Method not allowed. Only GET requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BlocksHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BlocksHandler.java
@@ -89,6 +89,7 @@ public class BlocksHandler extends HandlerBase {
 
     @Override
     protected void internalHandle(HttpExchange httpExchange) throws IOException {
+        if (resolvePreflight(httpExchange, "GET, PUT, OPTIONS", "Content-Type")) return;
 
         // query parameters
         Map<String, String> queryParams = parseQueryString(httpExchange.getRequestURI().getRawQuery());

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BlocksHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BlocksHandler.java
@@ -89,7 +89,9 @@ public class BlocksHandler extends HandlerBase {
 
     @Override
     protected void internalHandle(HttpExchange httpExchange) throws IOException {
-        if (resolvePreflight(httpExchange, "GET, PUT, OPTIONS", "Content-Type")) return;
+        if (resolvePreflight(httpExchange, "GET, PUT")) {
+			return;
+        }
 
         // query parameters
         Map<String, String> queryParams = parseQueryString(httpExchange.getRequestURI().getRawQuery());

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BuildAreaHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BuildAreaHandler.java
@@ -16,6 +16,7 @@ public class BuildAreaHandler extends HandlerBase {
 
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
+		if (resolvePreflight(httpExchange, "GET, OPTIONS", "Content-Type")) return;
 
 		if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
 			throw new HttpException("Method not allowed. Use GET method to request the build area.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BuildAreaHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/BuildAreaHandler.java
@@ -16,7 +16,9 @@ public class BuildAreaHandler extends HandlerBase {
 
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
-		if (resolvePreflight(httpExchange, "GET, OPTIONS", "Content-Type")) return;
+		if (resolvePreflight(httpExchange, "GET")) {
+			return;
+		}
 
 		if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
 			throw new HttpException("Method not allowed. Use GET method to request the build area.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/ChunksHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/ChunksHandler.java
@@ -26,7 +26,9 @@ public class ChunksHandler extends HandlerBase {
 
     @Override
     protected void internalHandle(HttpExchange httpExchange) throws IOException {
-        if (resolvePreflight(httpExchange, "GET, OPTIONS", "Content-Type, Accept, Accept-Encoding")) return;
+        if (resolvePreflight(httpExchange, "GET", "Content-Type, Accept, Accept-Encoding")) {
+			return;
+        }
 
         if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
             throw new HttpException("Method not allowed. Only GET requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/ChunksHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/ChunksHandler.java
@@ -26,6 +26,7 @@ public class ChunksHandler extends HandlerBase {
 
     @Override
     protected void internalHandle(HttpExchange httpExchange) throws IOException {
+        if (resolvePreflight(httpExchange, "GET, OPTIONS", "Content-Type, Accept, Accept-Encoding")) return;
 
         if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
             throw new HttpException("Method not allowed. Only GET requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/CommandHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/CommandHandler.java
@@ -29,6 +29,7 @@ public class CommandHandler extends HandlerBase {
 
     @Override
     protected void internalHandle(HttpExchange httpExchange) throws IOException {
+        if (resolvePreflight(httpExchange, "POST, OPTIONS", "Content-Type")) return;
 
 		if (!httpExchange.getRequestMethod().equalsIgnoreCase("post")) {
 			throw new HttpException("Method not allowed. Only POST requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/CommandHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/CommandHandler.java
@@ -29,7 +29,9 @@ public class CommandHandler extends HandlerBase {
 
     @Override
     protected void internalHandle(HttpExchange httpExchange) throws IOException {
-        if (resolvePreflight(httpExchange, "POST, OPTIONS", "Content-Type")) return;
+        if (resolvePreflight(httpExchange, "POST")) {
+			return;
+        }
 
 		if (!httpExchange.getRequestMethod().equalsIgnoreCase("post")) {
 			throw new HttpException("Method not allowed. Only POST requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/EntitiesHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/EntitiesHandler.java
@@ -60,7 +60,9 @@ public class EntitiesHandler extends HandlerBase {
 	}
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
-		if (resolvePreflight(httpExchange, "GET, PUT, PATCH, DELETE, OPTIONS", "Content-Type")) return;
+		if (resolvePreflight(httpExchange, "GET, PUT, PATCH, DELETE")) {
+			return;
+		}
 
 		// query parameters
 		Map<String, String> queryParams = parseQueryString(httpExchange.getRequestURI().getRawQuery());

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/EntitiesHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/EntitiesHandler.java
@@ -60,6 +60,7 @@ public class EntitiesHandler extends HandlerBase {
 	}
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
+		if (resolvePreflight(httpExchange, "GET, PUT, PATCH, DELETE, OPTIONS", "Content-Type")) return;
 
 		// query parameters
 		Map<String, String> queryParams = parseQueryString(httpExchange.getRequestURI().getRawQuery());

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/HandlerBase.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/HandlerBase.java
@@ -157,25 +157,31 @@ public abstract class HandlerBase implements HttpHandler {
      * 'Access-Control-Request-Method' header and returning the allowed methods/headers.
      *
      * @param httpExchange   The current HttpExchange object.
-     * @param allowedMethods A comma-separated string of permitted HTTP methods (e.g., "GET, PUT, OPTIONS").
+     * @param allowedMethods A comma-separated string of permitted HTTP methods (e.g., "GET, PUT").
      * @param allowedHeaders A comma-separated string of permitted request headers (e.g., "Content-Type").
      * @return true if the request was a preflight and was resolved, false if it should be processed as a standard request.
      * @throws IOException If an I/O error occurs while sending the response.
      */
-    protected boolean resolvePreflight(HttpExchange httpExchange, String allowedMethods, String allowedHeaders)
-            throws IOException {
+    protected static boolean resolvePreflight(HttpExchange httpExchange, String allowedMethods, String allowedHeaders) throws IOException {
         Headers requestHeaders = httpExchange.getRequestHeaders();
-
-        if (httpExchange.getRequestMethod().equalsIgnoreCase("options")
-                && requestHeaders.containsKey("Access-Control-Request-Method")) {
+        if (
+            httpExchange.getRequestMethod().equalsIgnoreCase("options") &&
+            requestHeaders.containsKey("Access-Control-Request-Method")
+        ) {
             Headers responseHeaders = httpExchange.getResponseHeaders();
             setDefaultResponseHeaders(responseHeaders);
-            responseHeaders.set("Access-Control-Allow-Methods", allowedMethods);
+            responseHeaders.set(
+                "Access-Control-Allow-Methods",
+                allowedMethods.isEmpty() ? "OPTIONS" : allowedMethods + ", OPTIONS"
+            );
             responseHeaders.set("Access-Control-Allow-Headers", allowedHeaders);
             httpExchange.sendResponseHeaders(204, -1);
             return true;
         }
         return false;
+    }
+    protected static boolean resolvePreflight(HttpExchange httpExchange, String allowedMethods) throws IOException {
+        return resolvePreflight(httpExchange, allowedMethods, "Content-Type");
     }
 
     /**

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/HandlerBase.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/HandlerBase.java
@@ -153,6 +153,32 @@ public abstract class HandlerBase implements HttpHandler {
     }
 
     /**
+     * Resolves CORS preflight (OPTIONS) requests by checking for the 
+     * 'Access-Control-Request-Method' header and returning the allowed methods/headers.
+     *
+     * @param httpExchange   The current HttpExchange object.
+     * @param allowedMethods A comma-separated string of permitted HTTP methods (e.g., "GET, PUT, OPTIONS").
+     * @param allowedHeaders A comma-separated string of permitted request headers (e.g., "Content-Type").
+     * @return true if the request was a preflight and was resolved, false if it should be processed as a standard request.
+     * @throws IOException If an I/O error occurs while sending the response.
+     */
+    protected boolean resolvePreflight(HttpExchange httpExchange, String allowedMethods, String allowedHeaders)
+            throws IOException {
+        Headers requestHeaders = httpExchange.getRequestHeaders();
+
+        if (httpExchange.getRequestMethod().equalsIgnoreCase("options")
+                && requestHeaders.containsKey("Access-Control-Request-Method")) {
+            Headers responseHeaders = httpExchange.getResponseHeaders();
+            setDefaultResponseHeaders(responseHeaders);
+            responseHeaders.set("Access-Control-Allow-Methods", allowedMethods);
+            responseHeaders.set("Access-Control-Allow-Headers", allowedHeaders);
+            httpExchange.sendResponseHeaders(204, -1);
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Helper to tell clients that response is formatted as JSON.
      *
      * @param headers request or response headers

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/HeightmapHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/HeightmapHandler.java
@@ -38,6 +38,7 @@ public class HeightmapHandler extends HandlerBase {
 
     @Override
     protected void internalHandle(HttpExchange httpExchange) throws IOException {
+        if (resolvePreflight(httpExchange, "GET, OPTIONS", "Content-Type")) return;
 
         if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
             throw new HttpException("Method not allowed. Only GET and POST requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/HeightmapHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/HeightmapHandler.java
@@ -38,7 +38,9 @@ public class HeightmapHandler extends HandlerBase {
 
     @Override
     protected void internalHandle(HttpExchange httpExchange) throws IOException {
-        if (resolvePreflight(httpExchange, "GET, OPTIONS", "Content-Type")) return;
+        if (resolvePreflight(httpExchange, "GET")) {
+			return;
+        }
 
         if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
             throw new HttpException("Method not allowed. Only GET and POST requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/InterfaceInfoHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/InterfaceInfoHandler.java
@@ -16,7 +16,9 @@ public class InterfaceInfoHandler extends HandlerBase {
 
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
-		if (resolvePreflight(httpExchange, "OPTIONS", "Content-Type")) return;
+		if (resolvePreflight(httpExchange, "")) {
+			return;
+		}
 
 		if (!httpExchange.getRequestMethod().equalsIgnoreCase("options")) {
 			throw new HttpException("Method not allowed. Only OPTIONS requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/InterfaceInfoHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/InterfaceInfoHandler.java
@@ -22,17 +22,8 @@ public class InterfaceInfoHandler extends HandlerBase {
 			throw new HttpException("Method not allowed. Only OPTIONS requests are supported.", 405);
 		}
 
-		Headers requestHeaders = httpExchange.getRequestHeaders();
 		Headers responseHeaders = httpExchange.getResponseHeaders();
 		setDefaultResponseHeaders(responseHeaders);
-
-		// Handle preflight requests
-		if (requestHeaders.containsKey("Access-Control-Request-Method")) {
-			responseHeaders.set("Access-Control-Allow-Methods", "OPTIONS");
-			responseHeaders.set("Access-Control-Allow-Headers", "Content-Type");
-			httpExchange.sendResponseHeaders(204, -1);
-			return;
-		}
 
 		JsonObject json = new JsonObject();
 		json.addProperty("minecraftVersion", SharedConstants.getCurrentVersion().name());

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/InterfaceInfoHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/InterfaceInfoHandler.java
@@ -16,13 +16,23 @@ public class InterfaceInfoHandler extends HandlerBase {
 
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
+		if (resolvePreflight(httpExchange, "OPTIONS", "Content-Type")) return;
 
 		if (!httpExchange.getRequestMethod().equalsIgnoreCase("options")) {
 			throw new HttpException("Method not allowed. Only OPTIONS requests are supported.", 405);
 		}
 
+		Headers requestHeaders = httpExchange.getRequestHeaders();
 		Headers responseHeaders = httpExchange.getResponseHeaders();
 		setDefaultResponseHeaders(responseHeaders);
+
+		// Handle preflight requests
+		if (requestHeaders.containsKey("Access-Control-Request-Method")) {
+			responseHeaders.set("Access-Control-Allow-Methods", "OPTIONS");
+			responseHeaders.set("Access-Control-Allow-Headers", "Content-Type");
+			httpExchange.sendResponseHeaders(204, -1);
+			return;
+		}
 
 		JsonObject json = new JsonObject();
 		json.addProperty("minecraftVersion", SharedConstants.getCurrentVersion().name());

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/MinecraftVersionHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/MinecraftVersionHandler.java
@@ -13,6 +13,7 @@ public class MinecraftVersionHandler extends HandlerBase {
 
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
+		if (resolvePreflight(httpExchange, "GET, OPTIONS", "Content-Type")) return;
 
 		if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
 			throw new HttpException("Method not allowed. Only GET requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/MinecraftVersionHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/MinecraftVersionHandler.java
@@ -13,7 +13,9 @@ public class MinecraftVersionHandler extends HandlerBase {
 
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
-		if (resolvePreflight(httpExchange, "GET, OPTIONS", "Content-Type")) return;
+		if (resolvePreflight(httpExchange, "GET")) {
+			return;
+		}
 
 		if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
 			throw new HttpException("Method not allowed. Only GET requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/PlayersHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/PlayersHandler.java
@@ -24,7 +24,9 @@ public class PlayersHandler extends HandlerBase {
     }
     @Override
     protected void internalHandle(HttpExchange httpExchange) throws IOException {
-        if (resolvePreflight(httpExchange, "GET, OPTIONS", "Content-Type")) return;
+        if (resolvePreflight(httpExchange, "GET")) {
+            return;
+        }
 
         if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
             throw new HttpException("Method not allowed. Only GET requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/PlayersHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/PlayersHandler.java
@@ -24,6 +24,7 @@ public class PlayersHandler extends HandlerBase {
     }
     @Override
     protected void internalHandle(HttpExchange httpExchange) throws IOException {
+        if (resolvePreflight(httpExchange, "GET, OPTIONS", "Content-Type")) return;
 
         if (!httpExchange.getRequestMethod().equalsIgnoreCase("get")) {
             throw new HttpException("Method not allowed. Only GET requests are supported.", 405);

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/StructureHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/StructureHandler.java
@@ -80,6 +80,7 @@ public class StructureHandler extends HandlerBase {
 
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
+		if (resolvePreflight(httpExchange, "GET, POST, OPTIONS", "Content-Type")) return;
 
 		// query parameters
 		Map<String, String> queryParams = parseQueryString(httpExchange.getRequestURI().getRawQuery());

--- a/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/StructureHandler.java
+++ b/common/src/main/java/nl/nielspoldervaart/gdmc/common/handlers/StructureHandler.java
@@ -80,7 +80,9 @@ public class StructureHandler extends HandlerBase {
 
 	@Override
 	protected void internalHandle(HttpExchange httpExchange) throws IOException {
-		if (resolvePreflight(httpExchange, "GET, POST, OPTIONS", "Content-Type")) return;
+		if (resolvePreflight(httpExchange, "GET, POST")) {
+			return;
+		}
 
 		// query parameters
 		Map<String, String> queryParams = parseQueryString(httpExchange.getRequestURI().getRawQuery());

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -75,7 +75,7 @@ The responses for all endpoints return with the following headers, unless stated
 
 ## CORS Preflight requests
 
-Although not explicitly documented below, all routes also support `OPTION` [CORS preflight requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request).
+Although not explicitly documented below, all routes also support `OPTIONS` [CORS preflight requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request).
 
 # 📜 Send Commands `POST /commands`
 

--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -73,6 +73,10 @@ The responses for all endpoints return with the following headers, unless stated
 | Content-Disposition         | `inline`                          |             |
 | Content-Type                | `application/json; charset=UTF-8` |             |
 
+## CORS Preflight requests
+
+Although not explicitly documented below, all routes also support `OPTION` [CORS preflight requests](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request).
+
 # 📜 Send Commands `POST /commands`
 
 Send one or more Minecraft console commands to the server. For the full list of all commands consult the [Minecraft commands documentation](https://minecraft.wiki/w/Commands#List_and_summary_of_commands).
@@ -128,7 +132,7 @@ each command will be executed line by line in the context of the overworld dimen
 ```json
 [
 	{
-		"status": 1,
+		"status": 1
 	},
 	{
 		"status": 1,


### PR DESCRIPTION
Goedemiddag!

I was playing around with the GDMC HTTP interface, but as I don't really use python I wanted to use the HTTP interface from a JS webapp, so I could also have some debug tooling UI. However, as the browser environment has all kind of security measures for obvious reasons, some requests to the HTTP interface failed due to cross-origin reasons.

In this PR, I implemented simple handlers for `OPTION` methods on all the routes, and added a special case for the info route that already uses the `OPTION` method. It's an if statement in each route now, I guess technically this could be extracted into a helper method. I have not fully completed versioning, partly due to me not being entirely sure whether this would technically be a new feature or a bugfix, and in part because of the release integration.

Although this started as a way for me personally to use the tool, I do feel like this makes the tool more compliant to regular HTTP traffic requirements in general.

Love to know what you think!